### PR TITLE
Remove disqus_identifier and use disqus_url instead

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -19,11 +19,6 @@ prose:
           element: 'hidden'
           value: CURRENT_DATETIME
 
-      - name: 'disqus_identifier'
-        field:
-          element: 'hidden'
-          value: UUID
-
       - name: 'published'
         field:
           element: 'hidden'

--- a/source/_disqus.erb
+++ b/source/_disqus.erb
@@ -3,7 +3,7 @@
   <script type="text/javascript">
     /* * * CONFIGURATION VARIABLES * * */
     var disqus_shortname = 'unboxedconsulting';
-    var disqus_identifier = '<%= disqus_identifier %>';
+    var disqus_url = 'https://www.unboxedconsulting.com/blog/<%= article_slug %>';
 
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {

--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -93,7 +93,7 @@
         </aside>
       </section>
 
-      <%= partial 'disqus', locals: { disqus_identifier: current_page.data.disqus_identifier } %>
+      <%= partial 'disqus', locals: { article_slug: current_page.slug } %>
 
       <% if current_article.similar_articles.any? %>
         <section class="blog-related">

--- a/source/templates/blog.md
+++ b/source/templates/blog.md
@@ -2,6 +2,6 @@
 layout: 'blog'
 title: '<%= @title %>'
 date: '<%= @date %>'
-disqus_identifier: '<%= SecureRandom.uuid %>'
+author: ''
 tags: # (Delete as appropiate) <%= "\n" + File.read('./data/tags.yml') %>
 ---


### PR DESCRIPTION
Unfortunately we could not add an identifier to existing Disqus threads, so instead we will be matching the threads from their previous URLs.
