### PR TITLE
Add mobile styles for blog tiles

### DIFF
--- a/source/assets/stylesheets/styles/_blog_large_tile.scss
+++ b/source/assets/stylesheets/styles/_blog_large_tile.scss
@@ -15,7 +15,6 @@
   box-sizing: border-box;
   background-color: $white;
   border: 1px solid darken($light-gray, 5%);
-  min-height: 386px;
   width: 100%;
 
   &:hover {
@@ -25,14 +24,22 @@
       border-color: transparent transparent transparent $light-gray;
     }
   }
+
+  @include breakpoint($tablet-breakpoint) {
+    min-height: 386px;
+  }
 }
 
 .blog-large-tile__top-content {
-  @include flexbox;
-  @include flex-direction(column);
-  @include justify-content(space-between);
   padding: 14px;
-  min-height: 140px;
+
+  @include breakpoint($tablet-breakpoint) {
+    @include flexbox;
+    @include flex-direction(column);
+    @include justify-content(space-between);
+
+    min-height: 140px;
+  }
 }
 
 .blog-large-tile__title {
@@ -40,10 +47,11 @@
   font-size: 1.14em;
   font-weight: lighter;
   line-height: 1.3em;
-  margin-bottom: 6px;
+  margin-bottom: 20px;
 
   @include breakpoint($tablet-breakpoint) {
     font-size: 2.17vw;
+    margin-bottom: 6px;
   }
 
   @include breakpoint($max-tablet-container) {
@@ -98,28 +106,36 @@
 
 .blog-large-tile__article-image-container {
   box-sizing: border-box;
-  float: right;
-  margin-left: 14px;
-  padding: 8px;
-  position: relative;
-  width: 50%;
+  padding: 8px 8px 0;
 
-  &:before {
-    border-color: transparent transparent transparent $white;
-    border-style: solid;
-    border-width: 18px 0 18px 24px;
-    content: '';
-    display: block;
-    height: 0;
-    position: absolute;
-    top: 32px;
-    width: 0;
+  @include breakpoint($tablet-breakpoint) {
+    float: right;
+    margin-left: 14px;
+    padding: 8px;
+    position: relative;
+    width: 50%;
+
+    &:before {
+      border-color: transparent transparent transparent $white;
+      border-style: solid;
+      border-width: 18px 0 18px 24px;
+      content: '';
+      display: block;
+      height: 0;
+      position: absolute;
+      top: 32px;
+      width: 0;
+    }
   }
 }
 
 .blog-large-tile__article-image {
   display: block;
-  height: 368px;
+  height: 130px;
   object-fit: cover;
   width: 100%;
+
+  @include breakpoint($tablet-breakpoint) {
+    height: 368px;
+  }
 }

--- a/source/assets/stylesheets/styles/_blog_medium_tile.scss
+++ b/source/assets/stylesheets/styles/_blog_medium_tile.scss
@@ -15,7 +15,6 @@
   box-sizing: border-box;
   background-color: $white;
   border: 1px solid darken($light-gray, 5%);
-  min-height: 386px;
   width: 100%;
 
   &:hover {
@@ -25,14 +24,26 @@
       border-top: 3px solid darken($light-gray, 5%);
     }
   }
+
+  @include breakpoint($tablet-breakpoint) {
+    min-height: 386px;
+
+    &:hover .blog-medium-tile__bottom-content {
+      border-top: 3px solid darken($light-gray, 5%);
+    }
+  }
 }
 
 .blog-medium-tile__top-content {
-  @include flexbox;
-  @include flex-direction(column);
-  @include justify-content(space-between);
   padding: 14px;
-  min-height: 140px;
+
+  @include breakpoint($tablet-breakpoint) {
+    @include flexbox;
+    @include flex-direction(column);
+    @include justify-content(space-between);
+
+    min-height: 140px;
+  }
 }
 
 .blog-medium-tile__title {
@@ -40,10 +51,11 @@
   font-size: 1.14em;
   font-weight: lighter;
   line-height: 1.3em;
-  margin-bottom: 6px;
+  margin-bottom: 20px;
 
   @include breakpoint($tablet-breakpoint) {
     font-size: 2.17vw;
+    margin-bottom: 6px;
   }
 
   @include breakpoint($max-tablet-container) {
@@ -64,7 +76,9 @@
 }
 
 .blog-medium-tile__bottom-content {
-  border-top: 3px solid $light-gray;
+  @include breakpoint($tablet-breakpoint) {
+    border-top: 3px solid $light-gray;
+  }
 }
 
 .blog-medium-tile__article-body {

--- a/source/assets/stylesheets/styles/_blog_small_tile.scss
+++ b/source/assets/stylesheets/styles/_blog_small_tile.scss
@@ -12,18 +12,22 @@
 }
 
 .blog-small-tile__content {
-  @include flexbox;
-  @include flex-direction(column);
-  @include justify-content(space-between);
   box-sizing: border-box;
   background-color: $white;
   padding: 14px 14px 14px;
   border: 1px solid darken($light-gray, 5%);
-  min-height: 190px;
   width: 100%;
 
   &:hover {
     background-color: $light-gray;
+  }
+
+  @include breakpoint($tablet-breakpoint) {
+    @include flexbox;
+    @include flex-direction(column);
+    @include justify-content(space-between);
+
+    min-height: 190px;
   }
 }
 
@@ -32,10 +36,11 @@
   font-size: 1.14em;
   font-weight: lighter;
   line-height: 1.3em;
-  margin-bottom: 6px;
+  margin-bottom: 20px;
 
   @include breakpoint($tablet-breakpoint) {
     font-size: 2.17vw;
+    margin-bottom: 6px;
   }
 
   @include breakpoint($max-tablet-container) {

--- a/source/blog.erb
+++ b/source/blog.erb
@@ -21,7 +21,7 @@
 <script>
 
   if (Modernizr.matchmedia) {
-    var mq  = matchMedia('(min-width: 660px)');
+    var mq = matchMedia('(min-width: 660px)');
     var $container = $('[data-packery-target]');
     var packeryOptions = {
       transitionDuration: 0,


### PR DESCRIPTION
Fixes:
- Large blog tiles are images are not the same length (ie. within the border) and text is longer than the image - reason for the large bottom gap (at least I think)
- Medium sized tiles - the description looks like a separate tile altogether and looks a little confusing

![screen shot 2015-10-15 at 13 38 42](https://cloud.githubusercontent.com/assets/885223/10513832/2af3cdcc-7342-11e5-9988-080044a024fc.png)
