### PR TITLE
Remove whitespace in linked blog author

### DIFF
--- a/source/layouts/blog_article.erb
+++ b/source/layouts/blog_article.erb
@@ -12,9 +12,7 @@
 
         <div class="blog-header__subtitle">
           <% if author %>
-            <a class="blog-header__author--linked" href="https://unboxedconsulting.com/people/<%= author.short_name %>">
-              <%= author.name %>
-            </a>
+            <a class="blog-header__author--linked" href="https://unboxedconsulting.com/people/<%= author.short_name %>"><%= author.name %></a>
           <% else %>
             <div class="blog-header__author">
               <%= current_page.data.author %>


### PR DESCRIPTION
The underline was going a character past the end of the name, if we drop the whitespace then it won't.  Hopefully.
