### PR TITLE
Rss for blog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'pry'
 gem 'redcarpet'
 gem 'middleman-blog'
 gem 'middleman-blog-similar'
+gem 'builder'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    builder (3.2.2)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     chunky_png (1.3.4)
@@ -154,6 +155,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  builder
   middleman
   middleman-blog
   middleman-blog-similar
@@ -163,4 +165,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/config.rb
+++ b/config.rb
@@ -35,6 +35,7 @@ ignore '/partials/*'
 ignore '/**/README.md'
 
 page "/blog/feed.xml", layout: false
+page "/blog/feed.rss", layout: false
 
 configure :build do
   activate :minify_css

--- a/config.rb
+++ b/config.rb
@@ -34,6 +34,8 @@ ignore '/templates/*'
 ignore '/partials/*'
 ignore '/**/README.md'
 
+page "/blog/feed.xml", layout: false
+
 configure :build do
   activate :minify_css
   activate :minify_javascript

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -14,4 +14,8 @@ module Helpers
   def is_matching_link?(href, current_url)
     href == current_url.match(/^(\/[^\/]*).*$/)[1]
   end
+
+  def atom_id(article)
+    "tag:unboxed.co,#{article.date.to_time.strftime('%Y-%m-%d')}:#{article.slug}"
+  end
 end

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -18,4 +18,8 @@ module Helpers
   def atom_id(article)
     "tag:unboxed.co,#{article.date.to_time.strftime('%Y-%m-%d')}:#{article.slug}"
   end
+
+  def add_atom_feed_to_head
+    content_for(:head) { feed_tag :atom, "#{blog.options.prefix.to_s}/feed.xml", title: "The Unboxed Blog" }
+  end
 end

--- a/source/blog.erb
+++ b/source/blog.erb
@@ -2,6 +2,7 @@
 title: "Blog"
 ---
 
+<% add_atom_feed_to_head %>
 <div class="blog-header">
   <div class="blog-header__container">
     <div class="blog-header__title">

--- a/source/blog/feed.rss.builder
+++ b/source/blog/feed.rss.builder
@@ -1,0 +1,31 @@
+xml.instruct! :xml, :version => "1.0"
+xml.rss :version => "2.0" do
+  xml.channel do
+    site_url = "http://unboxed.co/"
+    xml.title "The Unboxed Blog"
+    xml.description "Ruby on rails, Agile, Scrum and other life changing topics."
+    xml.link URI.join(site_url, blog.options.prefix.to_s)
+
+    blog.articles[0..50].each do |article|
+      xml.item do
+
+        xml.title article.title
+        xml.description article.body
+        xml.date article.date.to_time.rfc822
+        xml.link URI.join(site_url, article.url)
+        xml.guid atom_id(article)
+
+        author = data.people.detect { |person| person.name.downcase == article.data.author.downcase }
+        if author
+          xml.creator author.name
+          xml.tag! "dc:creator", author.name
+        else
+          xml.creator article.data.author
+          xml.tag! "dc:creator", article.data.author
+        end
+
+        xml.tag! "dc:date", article.date.to_time.rfc822
+      end
+    end
+  end
+end

--- a/source/blog/feed.xml.builder
+++ b/source/blog/feed.xml.builder
@@ -1,0 +1,31 @@
+xml.instruct!
+xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
+  site_url = "http://unboxed.co/"
+  xml.title "The Unboxed Blog"
+  xml.subtitle "Ruby on rails, Agile, Scrum and other life changing topics."
+  xml.id URI.join(site_url, blog.options.prefix.to_s)
+  xml.link "href" => URI.join(site_url, blog.options.prefix.to_s)
+  xml.link "href" => URI.join(site_url, current_page.path), "rel" => "self"
+  xml.updated(blog.articles.first.date.to_time.iso8601) unless blog.articles.empty?
+
+  blog.articles[0..50].each do |article|
+    xml.entry do
+      xml.title article.title
+      xml.link "rel" => "alternate", "href" => URI.join(site_url, article.url)
+      xml.id atom_id(article)
+      xml.published article.date.to_time.iso8601
+      xml.updated File.mtime(article.source_file).iso8601
+      xml.author do
+        author = data.people.detect { |person| person.name.downcase == article.data.author.downcase }
+        if author
+          xml.name author.name
+          xml.uri "https://unboxedconsulting.com/people/#{author.short_name}"
+        else
+          xml.name article.data.author
+        end
+      end
+      # xml.summary article.summary, "type" => "html"
+      xml.content article.body, "type" => "html"
+    end
+  end
+end

--- a/source/blog/tag.html.erb
+++ b/source/blog/tag.html.erb
@@ -1,3 +1,4 @@
+<% add_atom_feed_to_head %>
 <% content_for(:title) { "Blog - #{tagname}" } %>
 
 <div class="blog-header">

--- a/source/blog_author_grid.erb
+++ b/source/blog_author_grid.erb
@@ -1,3 +1,4 @@
+<% add_atom_feed_to_head %>
 <% content_for(:title) { "Blog - Posts by #{author_name}" } %>
 
 <div class="blog-header">

--- a/source/layouts/application.erb
+++ b/source/layouts/application.erb
@@ -23,6 +23,9 @@
       <%= javascript_include_tag "html5shiv.min" %>
       <%= stylesheet_link_tag "ie8_fixes" %>
     <![endif]-->
+    <% if content_for?(:head) %>
+      <%= yield_content(:head) %>
+    <% end %>
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
       ga('create', 'UA-1228281-4', 'unboxed.co');

--- a/source/layouts/blog_article.erb
+++ b/source/layouts/blog_article.erb
@@ -1,5 +1,6 @@
 <% author = data.people.detect { |person| person.name.downcase == current_page.data.author.downcase } %>
 <% content_for(:title) { "Blog - #{current_page.data.title}" } %>
+<% add_atom_feed_to_head %>
 
 <% wrap_layout :application do %>
   <section class="blog-article">

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -17,5 +17,15 @@ describe Helpers do
       expect(is_matching_link?('/project-stories', '/project-stories/sh24')).to be_truthy
     end
   end
+
+  describe 'atom_id' do
+    let(:date) { Time.parse('2014-10-29 11:40:32') }
+    let(:slug) { 'i-like-hats' }
+    let(:article) { double("BlogArtcile", date: date, slug: slug) }
+
+    it 'includes the website name, the short timestamp of the article, the article slug' do
+      expect(atom_id(article)).to eq "tag:unboxed.co,2014-10-29:i-like-hats"
+    end
+  end
 end
 


### PR DESCRIPTION
RSS/Atom have been broken since we redirected /blog on unboxedconsulting.com to unboxed.co.  This PR adds rss and atom feeds for the blog and puts links in the header for the atom feed and so replicates what ubxd_web did.  We'll need the redirect rules from unboxed/ubxd_web#90 to forward requests to here.

I couldn't find out how to add an issue for this to pivotal or whatever so I just found the time between client work to solve it myself.
