### PR TITLE
Remove blog's authors links to unboxedconsulting.com/people/individual-page

### DIFF
--- a/source/layouts/blog_article.erb
+++ b/source/layouts/blog_article.erb
@@ -15,7 +15,7 @@
 
         <div class="blog-header__subtitle">
           <% if author %>
-            <a class="blog-header__author--linked" href="https://unboxedconsulting.com/people/<%= author.short_name %>" rel="author">
+            <a class="blog-header__author--linked" href="/people/<%= author.short_name %>" rel="author">
               <%= author.name %>
             </a>
           <% else %>
@@ -65,7 +65,7 @@
             <img class="blog-author__image" src="/assets/images/people/<%= author.short_name %>.png" alt="<%= author.name %>"/>
           <% end %>
           <aside class="blog-author__right-section">
-            <a class="blog-author__name" href="https://unboxedconsulting.com/people/<%= author.short_name %>">
+            <a class="blog-author__name" href="/people/<%= author.short_name %>">
               <%= author.name %>
             </a>
             <div class="blog-author__bio">


### PR DESCRIPTION
and for now link them to the current individual people pages that we fetched from the old website. That will need to be changed when we implement our new people index page (there are no individual pages in a new design)

PT: https://www.pivotaltracker.com/projects/1364344/stories/111507302
