### PR TITLE
Remove BUNDLED WITH in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,3 @@ DEPENDENCIES
   pry
   redcarpet
   rspec
-
-BUNDLED WITH
-   1.10.6


### PR DESCRIPTION
After all the hassle of adding the message in
1.10, Bundler have removed the message again
in 1.11.
