### PR TITLE
Fix Safari overriding css class by `a:-webkit-any-link` color

### DIFF
--- a/source/assets/stylesheets/styles/_jobs_page_tile.scss
+++ b/source/assets/stylesheets/styles/_jobs_page_tile.scss
@@ -1,17 +1,40 @@
 .jobs-page-tile {
-  @extend .homepage-tile;
+  box-sizing: border-box;
+  display: block;
+  margin-bottom: 6px;
+  padding-right: 6px;
+  text-decoration: none;
+
+  @include breakpoint($tablet-breakpoint) {
+    float: left;
+    width: 33.33%;
+  }
+}
+
+.jobs-page-tile--linked {
+  @extend .jobs-page-tile;
+  color: darken($light-gray, 5%);
 }
 
 .jobs-page-tile__image {
-  @extend .homepage-tile__image;
+  display: block;
+  width: 100%;
 }
 
 .jobs-page-tile__content {
-  @extend .homepage-tile__content;
+  background-color: $white;
+  box-sizing: border-box;
+  padding: 8px;
+  border: 1px solid darken($light-gray, 5%);
+  width: 100%;
+
+  &:hover {
+    background-color: mix($white, $light-gray);
+  }
 }
 
 .jobs-page-tile__content--inactive {
-  @extend .homepage-tile__content;
+  @extend .jobs-page-tile__content;
 
   &:hover {
     background-color: $white;
@@ -19,10 +42,23 @@
 }
 
 .jobs-page-tile__title {
-  @extend .homepage-tile__title;
+  @include responsive-text;
   color: lighten($dark-gray, 15%);
+  padding: 14px 6px;
 }
 
 .jobs-page-tile__paragraph {
-  @extend .homepage-tile__paragraph;
+  color: $dark-gray;
+  padding: 0 6px 6px;
+  font-weight: 300;
+  line-height: 1.2em;
+
+  @include breakpoint($tablet-breakpoint) {
+    min-height: 11.5vw;
+  }
+
+  @include breakpoint($desktop-breakpoint) {
+    font-size: 1.1em;
+    min-height: 106px;
+  }
 }

--- a/source/jobs.erb
+++ b/source/jobs.erb
@@ -88,7 +88,8 @@ contact_us:
 
     <% current_page.data.roles.content.each do |role| %>
       <% if role.link %>
-        <a class="jobs-page-tile" href="<%= role.link %>" title="<%= role.name %>">
+        <!--we need to have this extra class to Safari bug - it's overriding anchor color and makes a border purple in the nested element-->
+        <a class="jobs-page-tile--linked" href="<%= role.link %>" title="<%= role.name %>">
           <div class="jobs-page-tile__content">
             <img class="jobs-page-tile__image" src="<%= role.image %>" alt="<%= role.name %>">
             <h3 class="jobs-page-tile__title">


### PR DESCRIPTION
What was causing a tile border to be purple, that was only happening when the middle tile was anchored/active.
