### PR TITLE
Fix bug in News index page on Chrome

### DIFF
--- a/source/assets/stylesheets/styles/_blog_medium_tile.scss
+++ b/source/assets/stylesheets/styles/_blog_medium_tile.scss
@@ -23,7 +23,7 @@
   }
 
   @include breakpoint($tablet-breakpoint) {
-    min-height: 386px;
+    min-height: 388px;
   }
 }
 

--- a/source/assets/stylesheets/styles/_news_tile.scss
+++ b/source/assets/stylesheets/styles/_news_tile.scss
@@ -3,15 +3,19 @@
 }
 
 .news-tile__container {
- @extend .blog-medium-tile__container;
+  @extend .blog-medium-tile__container;
+
+  @include breakpoint($tablet-breakpoint) {
+    height: 386px;
+ }
 }
 
 .news-tile__top-content {
- @extend .blog-medium-tile__top-content;
+  @extend .blog-medium-tile__top-content;
 }
 
 .news-tile__title {
- @extend .blog-medium-tile__title;
+  @extend .blog-medium-tile__title;
 }
 
 .news-tile__date {

--- a/source/assets/stylesheets/styles/_news_tile.scss
+++ b/source/assets/stylesheets/styles/_news_tile.scss
@@ -4,10 +4,6 @@
 
 .news-tile__container {
   @extend .blog-medium-tile__container;
-
-  @include breakpoint($tablet-breakpoint) {
-    height: 386px;
- }
 }
 
 .news-tile__top-content {


### PR DESCRIPTION
Chrome renders text in html element differently from FF and Safari. That was causing a problem
with changing a dimension of the news tile height, what was finally the reason of gaps in the next tiles row as the they were pushed down.
Setting fixed height on a tile container should be a solution.

(+ minor fixes in css intendation)

Screenshot of a bug:
<img width="1045" alt="screen shot 2016-03-03 at 22 03 29" src="https://cloud.githubusercontent.com/assets/5237879/13511136/d3362a7c-e18b-11e5-96f6-bce9534e4eaa.png">
