### PR TITLE
Reverse order of offices if users location is in South Africa

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -35,6 +35,9 @@ configure :development do
   activate :livereload
 end
 
+require 'json'
+require 'open-uri'
+
 require 'lib/helpers'
 helpers Helpers
 

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -30,4 +30,14 @@ module Helpers
   def add_atom_feed_to_head
     content_for(:head) { feed_tag :atom, "#{blog(:blog).options.prefix.to_s}/feed.xml", title: "The Unboxed Blog" }
   end
+
+  def office_location(offices)
+    location = JSON.parse(open('http://ipinfo.io').read)
+    # ZA for South Africa
+    if location["country"] == "ZA"
+      return offices.reverse
+    else
+      return offices
+    end
+  end
 end

--- a/source/contact.erb
+++ b/source/contact.erb
@@ -65,7 +65,7 @@ offices:
 </header>
 
 <div class="container--grid" data-header-waypoint>
-  <% current_page.data.offices.each do |office| %>
+  <% (office_location(current_page.data.offices)).each do |office| %>
     <div class="contact-page-tile">
       <div class="contact-page-tile__container">
 

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -1,4 +1,5 @@
 require './lib/helpers.rb'
+require 'json'
 include Helpers
 
 describe Helpers do
@@ -25,6 +26,25 @@ describe Helpers do
 
     it 'includes the website name, the short timestamp of the article, the article slug' do
       expect(atom_id(article)).to eq "tag:unboxed.co,2014-10-29:i-like-hats"
+    end
+  end
+
+  describe 'office_location' do 
+    helpers = Helpers
+    let(:offices) { ["london", "capetown"] }
+    let(:country_gb) { '{"country": "GB"}' }
+    let(:country_za) { '{"country": "ZA"}' }
+
+    it "should return the offices in their original order when the country is not South Africa (ZA)" do
+      allow(helpers).to receive_message_chain(:open, :read).and_return(country_gb)
+
+      expect(helpers.office_location(offices)).to eq ["london", "capetown"]
+    end
+
+    it "should return the offices in reverse order when the country is South Africa (ZA)" do
+      allow(helpers).to receive_message_chain(:open, :read).and_return(country_za)
+
+      expect(helpers.office_location(offices)).to eq ["capetown", "london"]
     end
   end
 end


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/112278943

Offices on the contact page will be reversed if location is
in South Africa, otherwise they will be in original order.
