### PR TITLE
Add blog post syntax highlighting via middleman-syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'middleman-blog'
 gem 'middleman-blog-similar'
 gem 'builder'
 gem 'middleman-sitemap'
+gem 'middleman-syntax'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,9 @@ GEM
       sprockets (~> 2.12.1)
       sprockets-helpers (~> 1.1.0)
       sprockets-sass (~> 1.3.0)
+    middleman-syntax (3.0.0)
+      middleman-core (>= 3.2)
+      rouge (~> 2.0)
     minitest (5.7.0)
     multi_json (1.11.2)
     padrino-helpers (0.12.5)
@@ -116,6 +119,7 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.3.2)
+    rouge (2.0.6)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -163,6 +167,7 @@ DEPENDENCIES
   middleman-blog-similar
   middleman-livereload
   middleman-sitemap
+  middleman-syntax
   pry
   redcarpet
   rspec

--- a/config.rb
+++ b/config.rb
@@ -31,6 +31,8 @@ activate :directory_indexes
 
 activate :sitemap, hostname: "https://unboxed.co"
 
+activate :syntax
+
 configure :development do
   activate :livereload
 end

--- a/source/blog/2016-09-05-docker-re-bundling.html.markdown
+++ b/source/blog/2016-09-05-docker-re-bundling.html.markdown
@@ -7,6 +7,7 @@ main_image: "http://i.imgur.com/jxhQ4jE.jpg"
 date: "2016-09-05 12:00 +0000"
 published: true
 title: "Development Re-bundling in Dockerland"
+has_syntax: true
 ---
 
 # Development Re-bundling in Dockerland
@@ -21,7 +22,7 @@ For those not familiar with Docker's vocabulary here's a quick intro. Docker con
 
 Images are built up in a series of 'layers'. Each layer represents a change to the previous layer. For example, this excerpt from a Dockerfile:
 
-```
+```dockerfile
 ...
 COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock
@@ -54,7 +55,7 @@ We came to the conclusion that it's not really possible to have a cache when bui
 
 First we created a bundle cache service in docker-compose, as outlined in the linked posts above:
 
-```
+```yml
 bundle_cache:
   image: busybox
   volumes:
@@ -63,7 +64,7 @@ bundle_cache:
 
 Next we created an entrypoint script for our container, this script runs bundle install before any command issued. Here the container command is run at `exec "$@"`, after checking and optionally installing the bundle.
 
-```
+```bash
 #!/bin/bash
 set -e
 
@@ -74,7 +75,7 @@ exec "$@"
 
 This entry point is then added used in our service Dockerfile:
 
-```
+```dockerfile
 FROM ruby
 
 WORKDIR /app

--- a/source/blog/2016-09-30-faster-than-lightning-september-s-developer-event.md
+++ b/source/blog/2016-09-30-faster-than-lightning-september-s-developer-event.md
@@ -6,6 +6,7 @@ author: Neil van Beinum
 tags:
   - Culture
   - Innovation
+has_syntax: true
 main_image: >-
   http://i1291.photobucket.com/albums/b548/grammccram/FTL%20dev%20talk%202%20-%20September_zpsldw6i9ou.png
 ---
@@ -27,14 +28,14 @@ We all place a high value on project documentation and setup instructions, regul
 **Q.** Why does this [template fragment][1] sometimes blow up with an
 encoding mismatch error on the second line?<br/>
 
-``` erb
+```erb
 <%= open_graph_tag 'url', request.original_url %>
 <%= open_graph_tag 'type', 'website' %>
 ```
 
 when doing the following request:<br/>
 
-``` bash
+```bash
 curl -I 'https://petition.parliament.uk/petitions?utf8=✓'
 ```
 
@@ -51,7 +52,7 @@ so you end up scratching your head wondering why it's happening.<br/>
 
 The fix is to make a helper that forces the encoding to UTF-8:<br/>
 
-``` ruby
+```ruby
 def original_url
   request.original_url.force_encoding('utf-8')
 end
@@ -59,7 +60,7 @@ end
 
 and use that in your template instead:
 
-``` erb
+```erb
 <%= open_graph_tag 'url', original_url %>
 ```
 
@@ -84,7 +85,7 @@ This code snippet is part of a work-in-progress project. I’ve been experimenti
 
 This function is part of a first attempt at this. It takes a hash of the person’s name and then converts any 0 characters to ‘G’s. It then strips out the numbers and attempts to populate the returned array with 6 characters representing musical notes. However, there are a couple of problems including the inability to handle hashes containing no letters. Following a discussion in the session I will look at converting the name into a series of base-7 numbers which represent the musical notes. I will also need to think about how to include  the various flat and sharp notes that are possible.<br/>
 
-```
+```javascript
 function leadChordNotes(winnerNameHash) {
   var NUMBER_OF_NOTES = 6,
       chordNotes = winnerNameHash.toUpperCase(),
@@ -114,7 +115,7 @@ function leadChordNotes(winnerNameHash) {
 
 I recently added a [linter](https://github.com/alphagov/govuk_lint) to a project I was working on, and running it produced a warning about this fragment of code:
 
-```
+```ruby
 def can_edit_site?(site_to_edit)
   can_edit_sites[site_to_edit.abbr] ||= begin
     gds_editor? ||
@@ -127,7 +128,7 @@ end
 
 It was complaing about the wrong indenting.  The linter also has an autocorrect mode so it also fixed the indenting to make the code look like this:
 
-```
+```ruby
 def can_edit_site?(site_to_edit)
   can_edit_sites[site_to_edit.abbr] ||= begin
     gds_editor? ||
@@ -140,7 +141,7 @@ end
 
 There were many other autocorrected linting violations in the PR I made so I didn't pay much attention to this.  Luckily, someone else on the team did and she asked me why we were getting the extra indent here as it looked odd.  It turns out that the linter wants you to indent an expression if you break it onto separate lines, which is what we'd done, but we hadn't realised that the expression we thought we'd written was more deeply nested than we thought.  [Ruby's operator precedence rules](https://ruby-doc.org/core-2.3.0/doc/syntax/precedence_rdoc.html) mean that `&&` binds more closely than `||`, so we'd introduced a subtle permissions bug.  After working this out we refactored to make the code clearer and ended up with this:
 
-```
+```ruby
 def can_edit_site?(site_to_edit)
   can_edit_sites[site_to_edit.abbr] ||= 
     site_is_editable?(site_to_edit) && has_permission_to_edit_site?(site_to_edit)

--- a/source/layouts/application.erb
+++ b/source/layouts/application.erb
@@ -28,6 +28,7 @@
     <% if current_page.data.has_syntax? %>
       <style>
         <%= Rouge::Themes::Github.render(:scope => '.highlight') %>
+        code { line-height: 20px; }
       </style>
     <% end %>
     <script>

--- a/source/layouts/application.erb
+++ b/source/layouts/application.erb
@@ -25,6 +25,11 @@
     <% if content_for?(:head) %>
       <%= yield_content(:head) %>
     <% end %>
+    <% if current_page.data.has_syntax? %>
+      <style>
+        <%= Rouge::Themes::Github.render(:scope => '.highlight') %>
+      </style>
+    <% end %>
     <script>
       function deferredScript(path) {
         function addScript(path) {


### PR DESCRIPTION
It's nicer if technical blog posts have highlighting. Makes them easier to read.

This makes use of middleman-syntax which makes use of rouge.

Styles for syntax highlighting are only included when there's a `has_syntax` flag in the post frontmatter.
