### PR TITLE
Enable posts to have a list of authors

### DIFF
--- a/lib/article_info.rb
+++ b/lib/article_info.rb
@@ -8,19 +8,13 @@ class ArticleInfo
 
   def authors
     @_authors ||= page_authors.map do |author_name|
-      people_data = people.detect do |person|
-        person.name.downcase == author_name.downcase
-      end
-
-      people_data || FormerEmployee.new(author_name)
+      find_person(author_name) || FormerEmployee.new(author_name)
     end
   end
 
   def current_authors
     @_current_authors ||= page_authors.map do |author_name|
-      people.detect do |person|
-        person.name.downcase == author_name.downcase
-      end
+      find_person(author_name)
     end.compact
   end
 
@@ -34,5 +28,9 @@ class ArticleInfo
 
   def page_authors
     @_page_authors ||= coauthors.unshift(page.author)
+  end
+
+  def find_person(author_name)
+    people.find { |person| person.name.downcase == author_name.downcase }
   end
 end

--- a/lib/article_info.rb
+++ b/lib/article_info.rb
@@ -1,0 +1,38 @@
+require './lib/former_employee'
+
+class ArticleInfo
+  def initialize(people, page)
+    @people = people
+    @page = page
+  end
+
+  def authors
+    @_authors ||= page_authors.map do |author_name|
+      people_data = people.detect do |person|
+        person.name.downcase == author_name.downcase
+      end
+
+      people_data || FormerEmployee.new(author_name)
+    end
+  end
+
+  def current_authors
+    @_current_authors ||= page_authors.map do |author_name|
+      people.detect do |person|
+        person.name.downcase == author_name.downcase
+      end
+    end.compact
+  end
+
+  private
+
+  attr_reader :page, :people
+
+  def coauthors
+    page.coauthors || []
+  end
+
+  def page_authors
+    @_page_authors ||= coauthors.unshift(page.author)
+  end
+end

--- a/lib/article_info.rb
+++ b/lib/article_info.rb
@@ -26,12 +26,8 @@ class ArticleInfo
 
   attr_reader :page, :people
 
-  def coauthors
-    page.coauthors || []
-  end
-
   def page_authors
-    @_page_authors ||= coauthors.unshift(page.author)
+    @_page_authors ||= page.authors || []
   end
 
   def find_person(author_name)

--- a/lib/article_info.rb
+++ b/lib/article_info.rb
@@ -1,4 +1,4 @@
-require './lib/former_employee'
+require './lib/non_employee'
 
 class ArticleInfo
   def initialize(people, page)
@@ -8,7 +8,7 @@ class ArticleInfo
 
   def authors
     @_authors ||= page_authors.map do |author_name|
-      find_person(author_name) || FormerEmployee.new(author_name)
+      find_person(author_name) || NonEmployee.new(author_name)
     end
   end
 

--- a/lib/article_info.rb
+++ b/lib/article_info.rb
@@ -18,6 +18,10 @@ class ArticleInfo
     end.compact
   end
 
+  def author_names
+    authors.map(&:name).join(", ")
+  end
+
   private
 
   attr_reader :page, :people

--- a/lib/former_employee.rb
+++ b/lib/former_employee.rb
@@ -1,0 +1,27 @@
+class FormerEmployee
+  attr_reader :name
+
+  def initialize(name)
+    @name = name
+  end
+
+  def short_name
+    ""
+  end
+
+  def role
+    ""
+  end
+
+  def email
+    ""
+  end
+
+  def bio
+    ""
+  end
+
+  def social_networks
+    []
+  end
+end

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1,3 +1,5 @@
+require './lib/article_info'
+
 module Helpers
   def retina_srcset(path)
     return %(src="#{path}") if path =~ /^http(s)?/
@@ -33,5 +35,9 @@ module Helpers
 
   def image_url(source)
     URI.join("http://unboxed.co/", image_path(source))
+  end
+
+  def article_info(people, page)
+    ArticleInfo.new(people, page)
   end
 end

--- a/lib/non_employee.rb
+++ b/lib/non_employee.rb
@@ -1,4 +1,4 @@
-class FormerEmployee
+class NonEmployee
   attr_reader :name
 
   def initialize(name)

--- a/lib/related_blog_articles.rb
+++ b/lib/related_blog_articles.rb
@@ -9,12 +9,10 @@ class RelatedBlogArticles
   end
 
   def author_weight
-    if @current.author.nil? && @other.author.nil?
+    if current_authors.empty? && other_authors.empty?
       0.0
-    elsif @current.author == @other.author
-      1.0
     else
-      0.0
+      (current_authors & other_authors).size.to_f / current_authors.size.to_f
     end
   end
 
@@ -24,6 +22,21 @@ class RelatedBlogArticles
     else
       (@current.tags & @other.tags).size.to_f / @current.tags.size.to_f
     end
+  end
+
+  private
+
+  attr_reader(
+    :current,
+    :other
+  )
+
+  def current_authors
+    current.authors || []
+  end
+
+  def other_authors
+    other.authors || []
   end
 end
 

--- a/source/_blog_large_tile.erb
+++ b/source/_blog_large_tile.erb
@@ -11,7 +11,7 @@
 
       <div>
         <div class="blog-large-tile__author" rel="author">
-          <%= article.data.author %>
+          <%= article_info(data.people, article.data).author_names %>
         </div>
 
         <div class="blog-large-tile__date">

--- a/source/_blog_medium_tile.erb
+++ b/source/_blog_medium_tile.erb
@@ -7,7 +7,7 @@
 
       <div>
         <div class="blog-medium-tile__author" rel="author">
-          <%= article.data.author %>
+          <%= article_info(data.people, article.data).author_names %>
         </div>
 
         <div class="blog-medium-tile__date">

--- a/source/_blog_small_tile.erb
+++ b/source/_blog_small_tile.erb
@@ -6,7 +6,7 @@
 
     <div>
       <div class="blog-small-tile__author" rel="author">
-        <%= article.data.author %>
+        <%= article_info(data.people, article.data).author_names %>
       </div>
 
       <div class="blog-small-tile__date">

--- a/source/blog/2009-07-19-a-brand-spanking-new-website.html.markdown
+++ b/source/blog/2009-07-19-a-brand-spanking-new-website.html.markdown
@@ -2,7 +2,8 @@
 date: "2009-07-19 00:00:00 UTC"
 published: true
 title: "A Brand Spanking New Website!"
-author: "Tom Dickinson"
+authors:
+  - "Tom Dickinson"
 tags:
   - Rails
 ---

--- a/source/blog/2009-07-23-agile-is-just-another-way-of-saying-let-s-use-common-sense.html.markdown
+++ b/source/blog/2009-07-23-agile-is-just-another-way-of-saying-let-s-use-common-sense.html.markdown
@@ -2,7 +2,8 @@
 date: "2009-07-23 00:00:00 UTC"
 published: true
 title: "Agile is just another way of saying – let’s use common sense!"
-author: "Tym Moore"
+authors:
+  - "Tym Moore"
 tags:
   - Rails
 ---

--- a/source/blog/2009-09-16-question-what-do-wags-dutch-total-football-and-agile-have-to-teach-us-about-effective-software-development-and-delivery.html.markdown
+++ b/source/blog/2009-09-16-question-what-do-wags-dutch-total-football-and-agile-have-to-teach-us-about-effective-software-development-and-delivery.html.markdown
@@ -2,7 +2,8 @@
 date: "2009-09-16 00:00:00 UTC"
 published: true
 title: "What do WAGs, Dutch \"total\" football, and Agile have to teach us about effective software dev. & delivery?"
-author: "Tym Moore"
+authors:
+  - "Tym Moore"
 tags:
   - Rails
 ---

--- a/source/blog/2009-10-22-less-is-more.html.markdown
+++ b/source/blog/2009-10-22-less-is-more.html.markdown
@@ -2,7 +2,8 @@
 date: "2009-10-22 00:00:00 UTC"
 published: true
 title: "Less is More"
-author: "Attila Gyorffy"
+authors:
+  - "Attila Gyorffy"
 tags:
   - Rails
 ---

--- a/source/blog/2009-11-03-businesses-are-agile-already-it-just-doesn-t-look-very-hard-to-find-it.html.markdown
+++ b/source/blog/2009-11-03-businesses-are-agile-already-it-just-doesn-t-look-very-hard-to-find-it.html.markdown
@@ -2,7 +2,8 @@
 date: "2009-11-03 00:00:00 UTC"
 published: true
 title: "Businesses are agile already - IT just doesn't look very hard to find it!"
-author: "Tim Higgins"
+authors:
+  - "Tim Higgins"
 tags:
   - Rails
 ---

--- a/source/blog/2009-11-23-the-curious-incident-of-the-named-scope-and-the-non-existent-array.html.markdown
+++ b/source/blog/2009-11-23-the-curious-incident-of-the-named-scope-and-the-non-existent-array.html.markdown
@@ -2,7 +2,8 @@
 date: "2009-11-23 00:00:00 UTC"
 published: true
 title: "The curious incident of the named scope and the non-existent array"
-author: "Jolyon Pawlyn"
+authors:
+  - "Jolyon Pawlyn"
 tags:
   - Rails
 ---

--- a/source/blog/2010-04-14-agile-in-enterprise.html.markdown
+++ b/source/blog/2010-04-14-agile-in-enterprise.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-04-14 00:00:00 UTC"
 published: true
 title: "Agile in Enterprise"
-author: "Yvonne Whittaker"
+authors:
+  - "Yvonne Whittaker"
 tags:
   - Rails
 ---

--- a/source/blog/2010-04-25-pair-programming-luxury-or-necessity.html.markdown
+++ b/source/blog/2010-04-25-pair-programming-luxury-or-necessity.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-04-25 00:00:00 UTC"
 published: true
 title: "Pair Programming - Luxury or Necessity?"
-author: "Tym Moore"
+authors:
+  - "Tym Moore"
 tags:
   - Rails
 ---

--- a/source/blog/2010-04-27-unboxed-opens-in-cape-town.html.markdown
+++ b/source/blog/2010-04-27-unboxed-opens-in-cape-town.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-04-27 00:00:00 UTC"
 published: true
 title: "We open our office in Cape Town"
-author: "Duncan Gurney"
+authors:
+  - "Duncan Gurney"
 tags:
   - Rails
 ---

--- a/source/blog/2010-04-30-the-good-years.html.markdown
+++ b/source/blog/2010-04-30-the-good-years.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-04-30 00:00:00 UTC"
 published: true
 title: "The Good Years"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Rails
 ---

--- a/source/blog/2010-05-30-css-id-and-class-naming.html.markdown
+++ b/source/blog/2010-05-30-css-id-and-class-naming.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-05-30 00:00:00 UTC"
 published: true
 title: "CSS id and class naming"
-author: "Simon Rentzke"
+authors:
+  - "Simon Rentzke"
 tags:
   - Rails
 ---

--- a/source/blog/2010-05-31-cucumber-iphone-icuke.html.markdown
+++ b/source/blog/2010-05-31-cucumber-iphone-icuke.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-05-31 00:00:00 UTC"
 published: true
 title: "Cucumber + iPhone = iCuke"
-author: "Rob Holland"
+authors:
+  - "Rob Holland"
 tags:
   - Rails
 ---

--- a/source/blog/2010-06-09-recipe-for-a-cape-town-office.html.markdown
+++ b/source/blog/2010-06-09-recipe-for-a-cape-town-office.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-06-09 00:00:00 UTC"
 published: true
 title: "Recipe for a Cape Town office"
-author: "Jolyon Pawlyn"
+authors:
+  - "Jolyon Pawlyn"
 tags:
   - Rails
 ---

--- a/source/blog/2010-07-25-scrum-in-the-deep-end.html.markdown
+++ b/source/blog/2010-07-25-scrum-in-the-deep-end.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-07-25 00:00:00 UTC"
 published: true
 title: "Scrum in the Deep End"
-author: "Karen van Vlaanderen"
+authors:
+  - "Karen van Vlaanderen"
 tags:
   - Rails
 ---

--- a/source/blog/2010-07-26-hacking-safari-s-auto-complete-feature.html.markdown
+++ b/source/blog/2010-07-26-hacking-safari-s-auto-complete-feature.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-07-26 00:00:00 UTC"
 published: true
 title: "Hacking Safari’s auto-complete feature"
-author: "Attila Gyorffy"
+authors:
+  - "Attila Gyorffy"
 tags:
   - Rails
 ---

--- a/source/blog/2010-07-27-wikileaks-war-logs-on-rails.html.markdown
+++ b/source/blog/2010-07-27-wikileaks-war-logs-on-rails.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-07-27 04:00:00 UTC"
 published: true
 title: "Wikileaks war logs on rails"
-author: "Tom ten Thij"
+authors:
+  - "Tom ten Thij"
 tags:
   - Rails
 ---

--- a/source/blog/2010-07-30-announcing-tabnav.html.markdown
+++ b/source/blog/2010-07-30-announcing-tabnav.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-07-30 13:00:00 UTC"
 published: true
 title: "Announcing: Tabnav"
-author: "Alex Tomlins"
+authors:
+  - "Alex Tomlins"
 tags:
   - Rails
 ---

--- a/source/blog/2010-07-31-a-code-review.html.markdown
+++ b/source/blog/2010-07-31-a-code-review.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-07-31 00:00:00 UTC"
 published: true
 title: "A++ code review"
-author: "Tim Higgins"
+authors:
+  - "Tim Higgins"
 tags:
   - Rails
 ---

--- a/source/blog/2010-08-10-rails-3-snowman-9731-and-rack-test.html.markdown
+++ b/source/blog/2010-08-10-rails-3-snowman-9731-and-rack-test.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-08-10 00:00:00 UTC"
 published: true
 title: "The abominable Rails 3 snowman doesn't like Rack-Test"
-author: "Alan Kennedy"
+authors:
+  - "Alan Kennedy"
 tags:
   - Rails
 ---

--- a/source/blog/2010-08-13-appetite-for-agile.html.markdown
+++ b/source/blog/2010-08-13-appetite-for-agile.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-08-13 00:00:00 UTC"
 published: true
 title: "Appetite for Agile"
-author: "Tom Dickinson"
+authors:
+  - "Tom Dickinson"
 tags:
   - Rails
 ---

--- a/source/blog/2010-08-13-which-js-unit-testing-framework.html.markdown
+++ b/source/blog/2010-08-13-which-js-unit-testing-framework.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-08-13 00:00:00 UTC"
 published: true
 title: "Which JS Unit Testing Framework?"
-author: "Petr Zaparka"
+authors:
+  - "Petr Zaparka"
 tags:
   - Rails
 ---

--- a/source/blog/2010-08-18-irc-completion-from-the-debugger.html.markdown
+++ b/source/blog/2010-08-18-irc-completion-from-the-debugger.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-08-18 11:09:00 UTC"
 published: true
 title: "IRB completion from the debugger"
-author: "Tom ten Thij"
+authors:
+  - "Tom ten Thij"
 tags:
   - Rails
 ---

--- a/source/blog/2010-08-20-i-m-not-working.html.markdown
+++ b/source/blog/2010-08-20-i-m-not-working.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-08-20 00:00:00 UTC"
 published: true
 title: "I'm not working"
-author: "Petr Zaparka"
+authors:
+  - "Petr Zaparka"
 tags:
   - Rails
 ---

--- a/source/blog/2010-09-06-what-car-is-your-website-2.html.markdown
+++ b/source/blog/2010-09-06-what-car-is-your-website-2.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-09-06 00:00:00 UTC"
 published: true
 title: "What car is your website?"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Rails
 ---

--- a/source/blog/2010-09-10-plenty-more-fish-in-the-sea.html.markdown
+++ b/source/blog/2010-09-10-plenty-more-fish-in-the-sea.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-09-10 00:00:00 UTC"
 published: true
 title: "Plenty more fish in the sea..."
-author: "Tom Dickinson"
+authors:
+  - "Tom Dickinson"
 tags:
   - Rails
 ---

--- a/source/blog/2010-09-15-one-week-iterations-rock.html.markdown
+++ b/source/blog/2010-09-15-one-week-iterations-rock.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-09-15 00:00:00 UTC"
 published: true
 title: "One Week Iterations Rock"
-author: "Austin Fagan"
+authors:
+  - "Austin Fagan"
 tags:
   - Rails
 ---

--- a/source/blog/2010-09-22-fix-your-broken-window-2.html.markdown
+++ b/source/blog/2010-09-22-fix-your-broken-window-2.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-09-22 00:00:00 UTC"
 published: true
 title: "Fix your broken window!"
-author: "Petr Zaparka"
+authors:
+  - "Petr Zaparka"
 tags:
   - Rails
 ---

--- a/source/blog/2010-09-28-road-trip.html.markdown
+++ b/source/blog/2010-09-28-road-trip.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-09-28 00:00:00 UTC"
 published: true
 title: "Road Trip"
-author: "Borja Arias"
+authors:
+  - "Borja Arias"
 tags:
   - Rails
 ---

--- a/source/blog/2010-09-29-shameless-plug.html.markdown
+++ b/source/blog/2010-09-29-shameless-plug.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-09-29 00:00:00 UTC"
 published: true
 title: "Shameless Plug"
-author: "Tom Dickinson"
+authors:
+  - "Tom Dickinson"
 tags:
   - Rails
 ---

--- a/source/blog/2010-10-04-our-applications-on-the-apple-app-store.html.markdown
+++ b/source/blog/2010-10-04-our-applications-on-the-apple-app-store.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-10-04 00:00:00 UTC"
 published: true
 title: "Our Applications on the Apple App Store"
-author: "Nigel Taylor"
+authors:
+  - "Nigel Taylor"
 tags:
   - Rails
 ---

--- a/source/blog/2010-10-05-unit-testing-on-the-iphone-sorry-what.html.markdown
+++ b/source/blog/2010-10-05-unit-testing-on-the-iphone-sorry-what.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-10-05 00:00:00 UTC"
 published: true
 title: "Unit testing on the iPhone"
-author: "Borja Arias"
+authors:
+  - "Borja Arias"
 tags:
   - Testing
   - Rails

--- a/source/blog/2010-10-06-newsletter-october-2010.html.markdown
+++ b/source/blog/2010-10-06-newsletter-october-2010.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-10-06 00:00:00 UTC"
 published: true
 title: "Newsletter - October 2010"
-author: "Tracey Berman"
+authors:
+  - "Tracey Berman"
 tags:
   - Rails
 ---

--- a/source/blog/2010-10-11-y-cuke.html.markdown
+++ b/source/blog/2010-10-11-y-cuke.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-10-11 00:00:00 UTC"
 published: true
 title: "y Cuke?"
-author: "Andrew Mitchell"
+authors:
+  - "Andrew Mitchell"
 tags:
   - Rails
 ---

--- a/source/blog/2010-10-15-new-version-of-planning-poker-for-iphone-ipod-touch-and-ipad.html.markdown
+++ b/source/blog/2010-10-15-new-version-of-planning-poker-for-iphone-ipod-touch-and-ipad.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-10-15 00:00:00 UTC"
 published: true
 title: "New version of Planning Poker for iPhone, iPod touch and iPad"
-author: "Nigel Taylor"
+authors:
+  - "Nigel Taylor"
 tags:
   - Rails
 ---

--- a/source/blog/2010-10-18-7-reasons-why-pair-programming-works.html.markdown
+++ b/source/blog/2010-10-18-7-reasons-why-pair-programming-works.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-10-18 00:00:00 UTC"
 published: true
 title: "7 reasons why pair programming works"
-author: "Petr Zaparka"
+authors:
+  - "Petr Zaparka"
 tags:
   - Rails
 ---

--- a/source/blog/2010-10-21-waterfall-syndrome.html.markdown
+++ b/source/blog/2010-10-21-waterfall-syndrome.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-10-21 00:00:00 UTC"
 published: true
 title: "Waterfall Syndrome"
-author: "Tim Higgins"
+authors:
+  - "Tim Higgins"
 tags:
   - Rails
 ---

--- a/source/blog/2010-10-25-agile-and-angry-birds.html.markdown
+++ b/source/blog/2010-10-25-agile-and-angry-birds.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-10-25 00:00:00 UTC"
 published: true
 title: "Agile and Angry Birds"
-author: "Tracey Berman"
+authors:
+  - "Tracey Berman"
 tags:
   - Rails
 ---

--- a/source/blog/2010-11-04-a-dev-s-point-of-view-agile-helps-focus.html.markdown
+++ b/source/blog/2010-11-04-a-dev-s-point-of-view-agile-helps-focus.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-11-04 00:00:00 UTC"
 published: true
 title: "A dev's point of view - agile helps focus."
-author: "Will Tomlins"
+authors:
+  - "Will Tomlins"
 tags:
   - Rails
 ---

--- a/source/blog/2010-11-08-in-white-space-no-one-can-hear-you-scream.html.markdown
+++ b/source/blog/2010-11-08-in-white-space-no-one-can-hear-you-scream.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-11-08 00:00:00 UTC"
 published: true
 title: "In White Space... No One Can Hear You Scream!"
-author: "Tom Dickinson"
+authors:
+  - "Tom Dickinson"
 tags:
   - Rails
 ---

--- a/source/blog/2010-11-10-pair-programming-with-your-mind.html.markdown
+++ b/source/blog/2010-11-10-pair-programming-with-your-mind.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-11-10 00:00:00 UTC"
 published: true
 title: "Pair programming with your mind"
-author: "Petr Zaparka"
+authors:
+  - "Petr Zaparka"
 tags:
   - Rails
 ---

--- a/source/blog/2010-11-12-don-t-let-the-train-make-you-strain.html.markdown
+++ b/source/blog/2010-11-12-don-t-let-the-train-make-you-strain.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-11-12 00:00:00 UTC"
 published: true
 title: "Don't let the Train make you Strain"
-author: "Nigel Taylor"
+authors:
+  - "Nigel Taylor"
 tags:
   - Rails
 ---

--- a/source/blog/2010-11-15-categorising-workarounds.html.markdown
+++ b/source/blog/2010-11-15-categorising-workarounds.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-11-15 00:00:00 UTC"
 published: true
 title: "Categorising Workarounds"
-author: "Austin Fagan"
+authors:
+  - "Austin Fagan"
 tags:
   - Rails
 ---

--- a/source/blog/2010-11-16-how-does-agile-development-fit-with-budgets-and-financial-controls.html.markdown
+++ b/source/blog/2010-11-16-how-does-agile-development-fit-with-budgets-and-financial-controls.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-11-16 00:00:00 UTC"
 published: true
 title: "How does agile development fit with budgets and financial controls?"
-author: "Tym Moore"
+authors:
+  - "Tym Moore"
 tags:
   - Rails
 ---

--- a/source/blog/2010-11-17-five-tv-a-k-a-project-cape-town.html.markdown
+++ b/source/blog/2010-11-17-five-tv-a-k-a-project-cape-town.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-11-17 00:00:00 UTC"
 published: true
 title: "five.tv a.k.a project Cape Town"
-author: "Jolyon Pawlyn"
+authors:
+  - "Jolyon Pawlyn"
 tags:
   - Rails
 ---

--- a/source/blog/2010-11-18-the-problem-with-software.html.markdown
+++ b/source/blog/2010-11-18-the-problem-with-software.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-11-18 00:00:00 UTC"
 published: true
 title: "The problem with software"
-author: "Borja Arias"
+authors:
+  - "Borja Arias"
 tags:
   - Rails
 ---

--- a/source/blog/2010-11-19-on-feedback-loops-and-agile.html.markdown
+++ b/source/blog/2010-11-19-on-feedback-loops-and-agile.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-11-19 00:00:00 UTC"
 published: true
 title: " On Feedback Loops and Agile"
-author: "Ben Wong"
+authors:
+  - "Ben Wong"
 tags:
   - Rails
 ---

--- a/source/blog/2010-11-22-not-so-cool-as-cucumber.html.markdown
+++ b/source/blog/2010-11-22-not-so-cool-as-cucumber.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-11-22 00:00:00 UTC"
 published: true
 title: "Not so cool as cucumber"
-author: "Jolyon Pawlyn"
+authors:
+  - "Jolyon Pawlyn"
 tags:
   - Rails
 ---

--- a/source/blog/2010-12-01-scrum-ban-aka-common-sense-in-agile.html.markdown
+++ b/source/blog/2010-12-01-scrum-ban-aka-common-sense-in-agile.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-12-01 00:00:00 UTC"
 published: true
 title: "Scrum-ban aka common sense in Agile"
-author: "Petr Zaparka"
+authors:
+  - "Petr Zaparka"
 tags:
   - Rails
 ---

--- a/source/blog/2010-12-01-shonky-internet-cowboy-builders-and-the-online-gold-rush.html.markdown
+++ b/source/blog/2010-12-01-shonky-internet-cowboy-builders-and-the-online-gold-rush.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-12-01 00:00:00 UTC"
 published: true
 title: "Shonky Internet - Cowboy Builders and the Online Gold Rush"
-author: "Tom Dickinson"
+authors:
+  - "Tom Dickinson"
 tags:
   - Rails
 ---

--- a/source/blog/2010-12-07-web-de-what-1-part-graphic-design-to-2-parts-user-interface-design.html.markdown
+++ b/source/blog/2010-12-07-web-de-what-1-part-graphic-design-to-2-parts-user-interface-design.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-12-07 00:00:00 UTC"
 published: true
 title: "Web De-What?! (1 Part Graphic Design to 2 Parts User-Interface Design). "
-author: "Tom Dickinson"
+authors:
+  - "Tom Dickinson"
 tags:
   - Rails
 ---

--- a/source/blog/2010-12-21-techhub-and-silicon-roundabout.html.markdown
+++ b/source/blog/2010-12-21-techhub-and-silicon-roundabout.html.markdown
@@ -2,7 +2,8 @@
 date: "2010-12-21 17:09:00 UTC"
 published: true
 title: "TechHub and Silicon Roundabout"
-author: "James Darling"
+authors:
+  - "James Darling"
 tags:
   - Rails
 ---

--- a/source/blog/2011-01-12-happiness-and-motivation-at-unboxed.html.markdown
+++ b/source/blog/2011-01-12-happiness-and-motivation-at-unboxed.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-01-12 10:38:00 UTC"
 published: true
 title: "Happiness and motivation"
-author: "Petr Zaparka"
+authors:
+  - "Petr Zaparka"
 tags:
   - Rails
 ---

--- a/source/blog/2011-01-18-a-thought-on-pair-programming.html.markdown
+++ b/source/blog/2011-01-18-a-thought-on-pair-programming.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-01-18 11:30:00 UTC"
 published: true
 title: "A thought on pair programming"
-author: "Borja Arias"
+authors:
+  - "Borja Arias"
 tags:
   - Rails
 ---

--- a/source/blog/2011-01-19-has-the-future-turned-out-the-way-it-was-supposed-to.html.markdown
+++ b/source/blog/2011-01-19-has-the-future-turned-out-the-way-it-was-supposed-to.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-01-19 17:07:00 UTC"
 published: true
 title: "Has the future turned out the way it was supposed to?"
-author: "Tom Dickinson"
+authors:
+  - "Tom Dickinson"
 tags:
   - Design
   - Rails

--- a/source/blog/2011-02-10-and-now-we-come-to-the-end-of-rubyfuza-now.html.markdown
+++ b/source/blog/2011-02-10-and-now-we-come-to-the-end-of-rubyfuza-now.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-02-10 14:35:00 UTC"
 published: true
 title: "And now we come to the end of RubyFuza.. now"
-author: "Karen van Vlaanderen"
+authors:
+  - "Karen van Vlaanderen"
 tags:
   - Rails
 ---

--- a/source/blog/2011-02-11-are-you-victim-of-stockholm-syndrome.html.markdown
+++ b/source/blog/2011-02-11-are-you-victim-of-stockholm-syndrome.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-02-11 17:15:00 UTC"
 published: true
 title: "Are you victim of Stockholm syndrome?"
-author: "Petr Zaparka"
+authors:
+  - "Petr Zaparka"
 tags:
   - Rails
 ---

--- a/source/blog/2011-02-17-git-rebase.html.markdown
+++ b/source/blog/2011-02-17-git-rebase.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-02-17 17:41:00 UTC"
 published: true
 title: "Git rebase"
-author: "Tom ten Thij"
+authors:
+  - "Tom ten Thij"
 tags:
   - Rails
 ---

--- a/source/blog/2011-02-25-agile-tools-for-the-support-team.html.markdown
+++ b/source/blog/2011-02-25-agile-tools-for-the-support-team.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-02-25 13:41:00 UTC"
 published: true
 title: "Agile Tools for the Support Team"
-author: "Austin Fagan"
+authors:
+  - "Austin Fagan"
 tags:
   - Agile
   - Testing

--- a/source/blog/2011-02-25-production-issues-and-3rd-line-support-processes.html.markdown
+++ b/source/blog/2011-02-25-production-issues-and-3rd-line-support-processes.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-02-25 14:53:00 UTC"
 published: true
 title: "Production Issues and 3rd Line Support Processes"
-author: "Austin Fagan"
+authors:
+  - "Austin Fagan"
 tags:
   - Agile
   - Testing

--- a/source/blog/2011-03-09-kanban-in-the-cape-part-1.html.markdown
+++ b/source/blog/2011-03-09-kanban-in-the-cape-part-1.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-03-09 08:45:00 UTC"
 published: true
 title: "Kanban in the Cape - Part 1"
-author: "Kevin Pedersen"
+authors:
+  - "Kevin Pedersen"
 tags:
   - Agile
   - Rails

--- a/source/blog/2011-03-13-steak-vs-cucumber-as-bdd-tools.html.markdown
+++ b/source/blog/2011-03-13-steak-vs-cucumber-as-bdd-tools.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-03-13 16:08:00 UTC"
 published: true
 title: "Steak vs Cucumber as BDD tools"
-author: "Petr Zaparka"
+authors:
+  - "Petr Zaparka"
 tags:
   - Testing
   - Rails

--- a/source/blog/2011-03-23-kanban-in-the-cape-part-2.html.markdown
+++ b/source/blog/2011-03-23-kanban-in-the-cape-part-2.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-03-23 12:10:00 UTC"
 published: true
 title: "Kanban in the Cape - Part 2"
-author: "Kevin Pedersen"
+authors:
+  - "Kevin Pedersen"
 tags:
   - Agile
   - Rails

--- a/source/blog/2011-04-15-i-m-a-scrummaster-huh.html.markdown
+++ b/source/blog/2011-04-15-i-m-a-scrummaster-huh.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-04-15 08:18:00 UTC"
 published: true
 title: "I'm a ScrumMaster. Huh?"
-author: "Kevin Pedersen"
+authors:
+  - "Kevin Pedersen"
 tags:
   - Agile
   - Lean

--- a/source/blog/2011-04-28-icon-or-ican-t-be-bothered.html.markdown
+++ b/source/blog/2011-04-28-icon-or-ican-t-be-bothered.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-04-28 15:06:00 UTC"
 published: true
 title: "Icon or Ican't be bothered."
-author: "Tom Dickinson"
+authors:
+  - "Tom Dickinson"
 tags:
   - Design
   - Rails

--- a/source/blog/2011-05-13-dealing-with-a-moving-target.html.markdown
+++ b/source/blog/2011-05-13-dealing-with-a-moving-target.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-05-13 21:20:00 UTC"
 published: true
 title: "Dealing with a moving target"
-author: "Alan Thomas"
+authors:
+  - "Alan Thomas"
 tags:
   - Agile
   - Rails

--- a/source/blog/2011-06-24-pivotal-tracker-workflow.html.markdown
+++ b/source/blog/2011-06-24-pivotal-tracker-workflow.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-06-24 10:46:00 UTC"
 published: true
 title: "Pivotal Tracker Workflow"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
   - Rails

--- a/source/blog/2011-07-04-mobilising-your-brand-web-vs-native-apps.html.markdown
+++ b/source/blog/2011-07-04-mobilising-your-brand-web-vs-native-apps.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-07-04 10:37:00 UTC"
 published: true
 title: "Mobilising your brand - mobile web vs native apps"
-author: "Juliet Prowse"
+authors:
+  - "Juliet Prowse"
 tags:
   - Rails
 ---

--- a/source/blog/2011-08-21-baselines.html.markdown
+++ b/source/blog/2011-08-21-baselines.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-08-21 20:33:00 UTC"
 published: true
 title: "Using baselines for effective planning"
-author: "Austin Fagan"
+authors:
+  - "Austin Fagan"
 tags:
   - Agile
   - Rails

--- a/source/blog/2011-08-30-xpath-and-escaping-a-comma.html.markdown
+++ b/source/blog/2011-08-30-xpath-and-escaping-a-comma.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-08-30 09:00:00 UTC"
 published: true
 title: "XPath and escaping a comma"
-author: "Jolyon Pawlyn"
+authors:
+  - "Jolyon Pawlyn"
 tags:
   - Rails
 ---

--- a/source/blog/2011-09-18-monitising-mobile-apps.html.markdown
+++ b/source/blog/2011-09-18-monitising-mobile-apps.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-09-18 09:37:00 UTC"
 published: true
 title: "Monetising mobile apps"
-author: "Juliet Prowse"
+authors:
+  - "Juliet Prowse"
 tags:
   - Rails
 ---

--- a/source/blog/2011-12-05-scrum-not-only-in-projects.html.markdown
+++ b/source/blog/2011-12-05-scrum-not-only-in-projects.html.markdown
@@ -2,7 +2,8 @@
 date: "2011-12-05 14:39:00 UTC"
 published: true
 title: "Scrum not only in projects"
-author: "Johanna Karlsson"
+authors:
+  - "Johanna Karlsson"
 tags:
   - Agile
 ---

--- a/source/blog/2012-02-15-forcing-facebook-to-update-your-site-s-metadata.html.markdown
+++ b/source/blog/2012-02-15-forcing-facebook-to-update-your-site-s-metadata.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-02-15 14:40:00 UTC"
 published: true
 title: "Forcing Facebook to Update Your Site's Metadata"
-author: "Alan Thomas"
+authors:
+  - "Alan Thomas"
 tags:
   - Innovation
 

--- a/source/blog/2012-02-22-agile-answers.html.markdown
+++ b/source/blog/2012-02-22-agile-answers.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-02-22 10:24:00 UTC"
 published: true
 title: "Agile Answers"
-author: "Elizabeth Curson"
+authors:
+  - "Elizabeth Curson"
 tags:
   - Agile
 ---

--- a/source/blog/2012-03-02-how-do-i-make-them-more-self-organising.html.markdown
+++ b/source/blog/2012-03-02-how-do-i-make-them-more-self-organising.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-03-02 13:23:00 UTC"
 published: true
 title: "How do I make my Agile Team more self-organising?"
-author: "Elizabeth Curson"
+authors:
+  - "Elizabeth Curson"
 tags:
   - Agile
 ---

--- a/source/blog/2012-03-11-gemnastics-with-activerecord.html.markdown
+++ b/source/blog/2012-03-11-gemnastics-with-activerecord.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-03-11 00:12:00 UTC"
 published: true
 title: "Gemnastics with ActiveRecord"
-author: "Christopher Patuzzo"
+authors:
+  - "Christopher Patuzzo"
 tags:
   - Rails
   - Testing

--- a/source/blog/2012-04-13-tackling-the-unknown-with-subdivision.html.markdown
+++ b/source/blog/2012-04-13-tackling-the-unknown-with-subdivision.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-04-13 23:32:00 UTC"
 published: true
 title: "Tackling the unknown with subdivision"
-author: "Christopher Patuzzo"
+authors:
+  - "Christopher Patuzzo"
 tags:
   - Testing
   - Rails

--- a/source/blog/2012-04-25-code-maintainability-is-it-a-test-thing.html.markdown
+++ b/source/blog/2012-04-25-code-maintainability-is-it-a-test-thing.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-04-25 12:52:00 UTC"
 published: true
 title: "Code maintainability - is it a test thing?"
-author: "Andrew Mitchell"
+authors:
+  - "Andrew Mitchell"
 tags:
   - Testing
   - Rails

--- a/source/blog/2012-05-10-the-week-in-links.html.markdown
+++ b/source/blog/2012-05-10-the-week-in-links.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-05-10 23:00:00 UTC"
 published: true
 title: "The Week In Links"
-author: "Luke Randall"
+authors:
+  - "Luke Randall"
 tags:
   - Rails
 ---

--- a/source/blog/2012-05-17-the-week-that-was.html.markdown
+++ b/source/blog/2012-05-17-the-week-that-was.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-05-17 23:00:00 UTC"
 published: true
 title: "The Week That Was"
-author: "Jolyon Pawlyn"
+authors:
+  - "Jolyon Pawlyn"
 tags:
   - Rails
 ---

--- a/source/blog/2012-05-24-the-week-of-winning.html.markdown
+++ b/source/blog/2012-05-24-the-week-of-winning.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-05-24 23:00:00 UTC"
 published: true
 title: "The Week Of Winning"
-author: "Chris Carter"
+authors:
+  - "Chris Carter"
 tags:
   - Rails
 ---

--- a/source/blog/2012-05-31-news-of-the-week.html.markdown
+++ b/source/blog/2012-05-31-news-of-the-week.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-05-31 23:00:00 UTC"
 published: true
 title: "News Of The Week"
-author: "Will Tomlins"
+authors:
+  - "Will Tomlins"
 tags:
   - Rails
 ---

--- a/source/blog/2012-06-07-news-news-news.html.markdown
+++ b/source/blog/2012-06-07-news-news-news.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-06-07 23:00:00 UTC"
 published: true
 title: "News News News"
-author: "Robert Pataki"
+authors:
+  - "Robert Pataki"
 tags:
   - Rails
 ---

--- a/source/blog/2012-06-12-making-javascript-testing-in-the-browser-not-suck-with-sinon-js-part-1.html.markdown
+++ b/source/blog/2012-06-12-making-javascript-testing-in-the-browser-not-suck-with-sinon-js-part-1.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-06-12 14:33:00 UTC"
 published: true
 title: "Making JavaScript testing in the browser not suck with Sinon.js (Part 1)"
-author: "Carl Whittaker"
+authors:
+  - "Carl Whittaker"
 tags:
   - Testing
 ---

--- a/source/blog/2012-06-14-the-week-the-newsletter-almost-became-purple.html.markdown
+++ b/source/blog/2012-06-14-the-week-the-newsletter-almost-became-purple.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-06-14 23:00:00 UTC"
 published: true
 title: "The Week The Newsletter Almost Became Purple"
-author: "Robert Fall"
+authors:
+  - "Robert Fall"
 tags:
   - Rails
 ---

--- a/source/blog/2012-06-21-the-week-in-dev.html.markdown
+++ b/source/blog/2012-06-21-the-week-in-dev.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-06-21 23:00:00 UTC"
 published: true
 title: "The Week In Dev"
-author: "Carl Whittaker"
+authors:
+  - "Carl Whittaker"
 tags:
   - Rails
 ---

--- a/source/blog/2012-06-28-this-week-in-dev.html.markdown
+++ b/source/blog/2012-06-28-this-week-in-dev.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-06-28 23:00:00 UTC"
 published: true
 title: "This Week In Dev"
-author: "Chris Carter"
+authors:
+  - "Chris Carter"
 tags:
   - Rails
 ---

--- a/source/blog/2012-07-08-better-late-than-never.html.markdown
+++ b/source/blog/2012-07-08-better-late-than-never.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-07-08 23:00:00 UTC"
 published: true
 title: "Better Late Than Never"
-author: "Seb Jacobs"
+authors:
+  - "Seb Jacobs"
 tags:
   - Rails
 ---

--- a/source/blog/2012-07-12-can-you-digg-it.html.markdown
+++ b/source/blog/2012-07-12-can-you-digg-it.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-07-12 23:00:00 UTC"
 published: true
 title: "Can You Digg It"
-author: "Christopher Patuzzo"
+authors:
+  - "Christopher Patuzzo"
 tags:
   - Rails
 ---

--- a/source/blog/2012-07-19-newsletter.html.markdown
+++ b/source/blog/2012-07-19-newsletter.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-07-19 23:00:00 UTC"
 published: true
 title: "Newsletter"
-author: "Grant Speelman"
+authors:
+  - "Grant Speelman"
 tags:
   - Rails
 ---

--- a/source/blog/2012-07-26-the-week-in-bitesize-chunks.html.markdown
+++ b/source/blog/2012-07-26-the-week-in-bitesize-chunks.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-07-26 23:00:00 UTC"
 published: true
 title: "The Week In Bitesize Chunks"
-author: "Andrew Mitchell"
+authors:
+  - "Andrew Mitchell"
 tags:
   - Rails
 ---

--- a/source/blog/2012-08-09-the-week-that-went-better-than-the-last.html.markdown
+++ b/source/blog/2012-08-09-the-week-that-went-better-than-the-last.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-08-09 23:00:00 UTC"
 published: true
 title: "The Week That Went Better Than The Last"
-author: "Andrew Mitchell"
+authors:
+  - "Andrew Mitchell"
 tags:
   - Rails
 ---

--- a/source/blog/2012-08-16-investigating-a-cms-toolset.html.markdown
+++ b/source/blog/2012-08-16-investigating-a-cms-toolset.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-08-16 15:39:00 UTC"
 published: true
 title: "Investigating a CMS Toolset"
-author: "Christopher Patuzzo"
+authors:
+  - "Christopher Patuzzo"
 tags:
   - Rails
 ---

--- a/source/blog/2012-08-21-one-month-and-eight-arms-starting-at-unboxed-consulting-and-launching-tentacles.html.markdown
+++ b/source/blog/2012-08-21-one-month-and-eight-arms-starting-at-unboxed-consulting-and-launching-tentacles.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-08-21 09:40:00 UTC"
 published: true
 title: "One Month and Eight Arms: Starting at Unboxed Consulting and Launching tentacl.es"
-author: "Tom Sabin"
+authors:
+  - "Tom Sabin"
 tags:
   - Culture
 

--- a/source/blog/2012-08-24-the-week-that-almost-didnt-happen.html.markdown
+++ b/source/blog/2012-08-24-the-week-that-almost-didnt-happen.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-08-24 15:10:00 UTC"
 published: true
 title: "The week that almost didn't happen"
-author: "Tom ten Thij"
+authors:
+  - "Tom ten Thij"
 tags:
   - Rails
 ---

--- a/source/blog/2012-08-31-this-weeks-round-up.html.markdown
+++ b/source/blog/2012-08-31-this-weeks-round-up.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-08-31 14:55:00 UTC"
 published: true
 title: "This weeks round up"
-author: "Lee Richmond"
+authors:
+  - "Lee Richmond"
 tags:
   - Rails
   - Innovation

--- a/source/blog/2012-09-07-the-squish-of-the-week.html.markdown
+++ b/source/blog/2012-09-07-the-squish-of-the-week.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-09-07 09:48:00 UTC"
 published: true
 title: "The squish of the week"
-author: "Jolyon Pawlyn"
+authors:
+  - "Jolyon Pawlyn"
 tags:
   - Rails
 ---

--- a/source/blog/2012-09-14-when-carlo-was-in-blightys-land.html.markdown
+++ b/source/blog/2012-09-14-when-carlo-was-in-blightys-land.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-09-14 15:59:00 UTC"
 published: true
 title: "When Carlo was in Blighty's Land"
-author: "Carlo Kruger"
+authors:
+  - "Carlo Kruger"
 tags:
   - Rails
 ---

--- a/source/blog/2012-09-21-boomboxed.html.markdown
+++ b/source/blog/2012-09-21-boomboxed.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-09-21 15:04:00 UTC"
 published: true
 title: "Boomboxed"
-author: "Robert Pataki"
+authors:
+  - "Robert Pataki"
 tags:
   - Rails
 ---

--- a/source/blog/2012-09-28-rspec-sitemap-matchers-for-your-seo-goodness.html.markdown
+++ b/source/blog/2012-09-28-rspec-sitemap-matchers-for-your-seo-goodness.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-09-28 11:47:00 UTC"
 published: true
 title: "RSpec Sitemap matchers for your SEO goodness"
-author: "Attila Gyorffy"
+authors:
+  - "Attila Gyorffy"
 tags:
   - Rails
 ---

--- a/source/blog/2012-10-01-newsletter-1st-october.html.markdown
+++ b/source/blog/2012-10-01-newsletter-1st-october.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-10-01 10:22:00 UTC"
 published: true
 title: "Newsletter, 1st October"
-author: "Attila Gyorffy"
+authors:
+  - "Attila Gyorffy"
 tags:
   - Rails
 ---

--- a/source/blog/2012-10-05-what-5th-october-says.html.markdown
+++ b/source/blog/2012-10-05-what-5th-october-says.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-10-05 15:00:00 UTC"
 published: true
 title: "What 5th October says"
-author: "Grant Speelman"
+authors:
+  - "Grant Speelman"
 tags:
   - Rails
 ---

--- a/source/blog/2012-10-12-october-is-all-about-speed.html.markdown
+++ b/source/blog/2012-10-12-october-is-all-about-speed.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-10-12 11:53:00 UTC"
 published: true
 title: "October is all about speed"
-author: "Pawel Janiak"
+authors:
+  - "Pawel Janiak"
 tags:
   - Rails
 ---

--- a/source/blog/2012-10-12-prioritising-production-bugs.html.markdown
+++ b/source/blog/2012-10-12-prioritising-production-bugs.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-10-12 14:46:00 UTC"
 published: true
 title: "Prioritising production bugs"
-author: "Austin Fagan"
+authors:
+  - "Austin Fagan"
 tags:
   - Testing
 ---

--- a/source/blog/2012-10-19-this-week-in-ruby-19th-october.html.markdown
+++ b/source/blog/2012-10-19-this-week-in-ruby-19th-october.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-10-19 15:12:00 UTC"
 published: true
 title: "This Week in Ruby, 19th October"
-author: "Leo Cassarani"
+authors:
+  - "Leo Cassarani"
 tags:
   - Rails
 ---

--- a/source/blog/2012-10-22-making-javascript-testing-in-the-browser-not-suck-with-sinonjs-part-2.html.markdown
+++ b/source/blog/2012-10-22-making-javascript-testing-in-the-browser-not-suck-with-sinonjs-part-2.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-10-22 14:06:00 UTC"
 published: true
 title: "Making JavaScript testing in the browser not suck with Sinon.js (Part 2)"
-author: "Carl Whittaker"
+authors:
+  - "Carl Whittaker"
 tags:
   - Testing
 ---

--- a/source/blog/2012-10-26-the-week-of-the-javascript-take-over.html.markdown
+++ b/source/blog/2012-10-26-the-week-of-the-javascript-take-over.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-10-26 15:02:00 UTC"
 published: true
 title: "The Week of the JavaScript take over"
-author: "Carl Whittaker"
+authors:
+  - "Carl Whittaker"
 tags:
   - Rails
 ---

--- a/source/blog/2012-10-30-agile-newsletter-30-oct.html.markdown
+++ b/source/blog/2012-10-30-agile-newsletter-30-oct.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-10-30 10:37:00 UTC"
 published: true
 title: "Agile Newsletter - 30 Oct"
-author: "Carlo Kruger"
+authors:
+  - "Carlo Kruger"
 tags:
   - Agile
 ---

--- a/source/blog/2012-11-02-dev-newsletter-2-november-2012.html.markdown
+++ b/source/blog/2012-11-02-dev-newsletter-2-november-2012.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-11-02 15:06:00 UTC"
 published: true
 title: "Dev Newsletter: 2 November 2012"
-author: "Richard Archer"
+authors:
+  - "Richard Archer"
 tags:
   - Rails
 ---

--- a/source/blog/2012-11-09-the-week-with-no-activesupport-favourite-method.html.markdown
+++ b/source/blog/2012-11-09-the-week-with-no-activesupport-favourite-method.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-11-09 15:51:00 UTC"
 published: true
 title: "The week with no ActiveSupport favourite method"
-author: "Matt Peperell"
+authors:
+  - "Matt Peperell"
 tags:
   - Rails
 ---

--- a/source/blog/2012-11-16-new-version-of-rails-a-new-patch-level-of-ruby-193-and-kittens-oh-my.html.markdown
+++ b/source/blog/2012-11-16-new-version-of-rails-a-new-patch-level-of-ruby-193-and-kittens-oh-my.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-11-16 18:19:00 UTC"
 published: true
 title: "New version of Rails, a new patch level of Ruby 1.9.3 and kittens, oh my!"
-author: "Attila Gyorffy"
+authors:
+  - "Attila Gyorffy"
 tags:
   - Culture
   - Rails

--- a/source/blog/2012-11-23-return-of-the-activesupport-method-of-the-week-mark-morrison-style.html.markdown
+++ b/source/blog/2012-11-23-return-of-the-activesupport-method-of-the-week-mark-morrison-style.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-11-23 14:42:00 UTC"
 published: true
 title: "Return Of The ActiveSupport method of the week (Mark Morrison style)"
-author: "Carl Whittaker"
+authors:
+  - "Carl Whittaker"
 tags:
   - Rails
 ---

--- a/source/blog/2012-11-26-installing-sphinx-09-on-mountain-lion-using-homebrew.html.markdown
+++ b/source/blog/2012-11-26-installing-sphinx-09-on-mountain-lion-using-homebrew.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-11-26 18:25:00 UTC"
 published: true
 title: "Installing Sphinx 0.9 on Mountain Lion using Homebrew"
-author: "Attila Gyorffy"
+authors:
+  - "Attila Gyorffy"
 tags:
   - Rails
 

--- a/source/blog/2012-11-30-this-week-faster-rails-tests-interactive-video-lovely-interfaces-and-the-history-of-bbc-news-online.html.markdown
+++ b/source/blog/2012-11-30-this-week-faster-rails-tests-interactive-video-lovely-interfaces-and-the-history-of-bbc-news-online.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-11-30 15:08:00 UTC"
 published: true
 title: "This week: Faster Rails tests, Interactive Video,  Lovely Interfaces and the history of BBC News online"
-author: "Richard Archer"
+authors:
+  - "Richard Archer"
 tags:
   - Rails
 ---

--- a/source/blog/2012-12-07-cucumbers-missed-high-fives-dancing-hungarians-and-more.html.markdown
+++ b/source/blog/2012-12-07-cucumbers-missed-high-fives-dancing-hungarians-and-more.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-12-07 15:21:00 UTC"
 published: true
 title: "Cucumbers, Missed High Fives, Dancing Hungarians and more..."
-author: "Lee Richmond"
+authors:
+  - "Lee Richmond"
 tags:
   - Rails
 ---

--- a/source/blog/2012-12-10-html5-validation-that-does-not-hurt.html.markdown
+++ b/source/blog/2012-12-10-html5-validation-that-does-not-hurt.html.markdown
@@ -2,7 +2,8 @@
 date: "2012-12-10 12:10:00 UTC"
 published: true
 title: "HTML5 validation that does not hurt"
-author: "Attila Gyorffy"
+authors:
+  - "Attila Gyorffy"
 tags:
   - Rails
 ---

--- a/source/blog/2012-12-17-this-weeks-dev-newsletter.html.markdown
+++ b/source/blog/2012-12-17-this-weeks-dev-newsletter.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-12-17 15:58:00 UTC"
 published: true
 title: "This week's Dev Newsletter"
-author: "Leo Cassarani"
+authors:
+  - "Leo Cassarani"
 tags:
   - Rails
 ---

--- a/source/blog/2012-12-21-post-end-of-the-world-newsletter-yay-were-still-here.html.markdown
+++ b/source/blog/2012-12-21-post-end-of-the-world-newsletter-yay-were-still-here.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2012-12-21 16:54:00 UTC"
 published: true
 title: "Post-end-of-the-world newsletter - yay we're still here "
-author: "Tom ten Thij"
+authors:
+  - "Tom ten Thij"
 tags:
   - Rails
 ---

--- a/source/blog/2013-01-11-happy-2013-dev-newletter.html.markdown
+++ b/source/blog/2013-01-11-happy-2013-dev-newletter.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-01-11 15:47:00 UTC"
 published: true
 title: "Happy 2013 Dev Newletter"
-author: "Elizabeth Curson"
+authors:
+  - "Elizabeth Curson"
 tags:
   - Rails
 ---

--- a/source/blog/2013-01-21-apps-games-and-some-serious-business.html.markdown
+++ b/source/blog/2013-01-21-apps-games-and-some-serious-business.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-01-21 12:46:00 UTC"
 published: true
 title: "Apps, games and some serious business"
-author: "Robert Pataki"
+authors:
+  - "Robert Pataki"
 tags:
   - Rails
 ---

--- a/source/blog/2013-01-25-short-and-sweet.html.markdown
+++ b/source/blog/2013-01-25-short-and-sweet.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-01-25 12:20:00 UTC"
 published: true
 title: Short and sweet
-author: Pawel Janiak
+authors:
+  - Pawel Janiak
 tags: 
   - Culture
 main_image: ""

--- a/source/blog/2013-02-01-developer-newsletter-of-hope-1-feb-2013.html.markdown
+++ b/source/blog/2013-02-01-developer-newsletter-of-hope-1-feb-2013.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-02-01 14:13:00 UTC"
 published: true
 title: "A New Hope"
-author: "Ben Wong"
+authors:
+  - "Ben Wong"
 tags:
   - Rails
 ---

--- a/source/blog/2013-02-06-three-common-misconceptions-about-agile-in-the-public-sector.html.markdown
+++ b/source/blog/2013-02-06-three-common-misconceptions-about-agile-in-the-public-sector.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-02-06 10:06:00 UTC"
 published: true
 title: "Three common misconceptions about Agile in the public sector "
-author: Steve Lennon
+authors:
+  - Steve Lennon
 tags: 
   - Agile
 main_image: ""

--- a/source/blog/2013-02-08-hello.html.markdown
+++ b/source/blog/2013-02-08-hello.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-02-08 12:36:00 UTC"
 published: true
 title: "There's something in the woodshed"
-author: "Jolyon Pawlyn"
+authors:
+  - "Jolyon Pawlyn"
 tags:
   - Rails
 ---

--- a/source/blog/2013-02-18-five-myths-about-smes-and-public-sector-procurement.html.markdown
+++ b/source/blog/2013-02-18-five-myths-about-smes-and-public-sector-procurement.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-02-18 10:12:00 UTC"
 published: true
 title: Five myths about SMEs and public sector procurement
-author: Richard Stobart
+authors:
+  - Richard Stobart
 tags: 
   - Agile
 main_image: ""

--- a/source/blog/2013-02-20-open-device-lab-in-cape-town.html.markdown
+++ b/source/blog/2013-02-20-open-device-lab-in-cape-town.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-02-20 09:36:00 UTC"
 published: true
 title: "Open Device Lab in Cape Town"
-author: "Steve Barnett"
+authors:
+  - "Steve Barnett"
 tags:
   - Culture
   - Innovation

--- a/source/blog/2013-02-21-new-apprentice-luke-ben.html.markdown
+++ b/source/blog/2013-02-21-new-apprentice-luke-ben.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-02-21 12:44:00 UTC"
 published: true
 title: "New Apprentices - Luke & Ben"
-author: "Luke Bennett"
+authors:
+  - "Luke Bennett"
 tags:
   - Culture
 

--- a/source/blog/2013-02-21-new-apprentice-shirin.html.markdown
+++ b/source/blog/2013-02-21-new-apprentice-shirin.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-02-21 12:18:00 UTC"
 published: true
 title: "New Apprentice - Shirin"
-author: "Shirin Ullah"
+authors:
+  - "Shirin Ullah"
 tags:
   - Culture
 

--- a/source/blog/2013-02-21-new-apprentices-abbie-tillie.html.markdown
+++ b/source/blog/2013-02-21-new-apprentices-abbie-tillie.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-02-21 12:14:00 UTC"
 published: true
 title: "New Apprentices - Abbie & Tillie"
-author: "Abbie Ferguson"
+authors:
+  - "Abbie Ferguson"
 tags:
   - Culture
 

--- a/source/blog/2013-02-22-this-weeks-dev-newsletter-2.html.markdown
+++ b/source/blog/2013-02-22-this-weeks-dev-newsletter-2.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-02-22 14:04:00 UTC"
 published: true
 title: "This week's dev newsletter"
-author: "Matt Peperell"
+authors:
+  - "Matt Peperell"
 tags:
   - Rails
 ---

--- a/source/blog/2013-02-28-five-cardinal-sins-of-agile-that-the-public-sector-can-learn-from.html.markdown
+++ b/source/blog/2013-02-28-five-cardinal-sins-of-agile-that-the-public-sector-can-learn-from.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-02-28 14:35:00 UTC"
 published: true
 title: "Five Cardinal Sins of Agile that the public sector can learn from"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
 

--- a/source/blog/2013-02-28-sa-ux-forum-mobile-ux.html.markdown
+++ b/source/blog/2013-02-28-sa-ux-forum-mobile-ux.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-02-28 09:31:00 UTC"
 published: true
 title: "SA UX Forum: Mobile UX"
-author: "Steve Barnett"
+authors:
+  - "Steve Barnett"
 tags:
   - Design
 ---

--- a/source/blog/2013-03-01-this-weeks-developer-newsletter-cats-conferences-and-cascading-style-sheets.html.markdown
+++ b/source/blog/2013-03-01-this-weeks-developer-newsletter-cats-conferences-and-cascading-style-sheets.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-03-01 15:26:00 UTC"
 published: true
 title: "This week's developer newsletter - cats, conferences, and cascading style sheets"
-author: "Andrew Mitchell"
+authors:
+  - "Andrew Mitchell"
 tags:
   - Rails
   - Design

--- a/source/blog/2013-03-08-improve-your-week-with-this-1-weird-old-tip.html.markdown
+++ b/source/blog/2013-03-08-improve-your-week-with-this-1-weird-old-tip.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-03-08 15:33:00 UTC"
 published: true
 title: "Improve your week with this 1 weird old tip"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2013-03-12-five-facilitation-techniques-for-promoting-agile-for-government.html.markdown
+++ b/source/blog/2013-03-12-five-facilitation-techniques-for-promoting-agile-for-government.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-03-12 10:00:00 UTC"
 published: true
 title: Five facilitation techniques for promoting Agile for government
-author: Richard Stobart
+authors:
+  - Richard Stobart
 tags: 
   - Agile
 main_image: ""

--- a/source/blog/2013-03-12-national-apprenticeship-week-2.html.markdown
+++ b/source/blog/2013-03-12-national-apprenticeship-week-2.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-03-12 15:17:00 UTC"
 published: true
 title: National Apprenticeship Week
-author: Tillie McCarthy
+authors:
+  - Tillie McCarthy
 tags: 
   - Culture
 main_image: ""

--- a/source/blog/2013-03-15-rich-archers-talk-at-cape-town-front-end-developers.html.markdown
+++ b/source/blog/2013-03-15-rich-archers-talk-at-cape-town-front-end-developers.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-03-15 10:18:00 UTC"
 published: true
 title: "Rich Archer's talk at Cape Town Front End Developers"
-author: "Steve Barnett"
+authors:
+  - "Steve Barnett"
 tags:
   - Culture
 

--- a/source/blog/2013-03-16-daring-snowball.html.markdown
+++ b/source/blog/2013-03-16-daring-snowball.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-03-16 07:13:00 UTC"
 published: true
 title: "Daring Snowball"
-author: "Pawel Janiak"
+authors:
+  - "Pawel Janiak"
 tags:
   - Rails
 ---

--- a/source/blog/2013-03-22-insert-your-own-punny-title-for-the-developer-newsletter-here.html.markdown
+++ b/source/blog/2013-03-22-insert-your-own-punny-title-for-the-developer-newsletter-here.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-03-22 14:56:00 UTC"
 published: true
 title: "[Insert your own punny title for the Developer newsletter here]"
-author: "Richard Archer"
+authors:
+  - "Richard Archer"
 tags:
   - Rails
 ---

--- a/source/blog/2013-04-02-dev-newsletter-for-the-week.html.markdown
+++ b/source/blog/2013-04-02-dev-newsletter-for-the-week.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-04-02 16:01:00 UTC"
 published: true
 title: "Dev Newsletter for the week"
-author: "Leo Cassarani"
+authors:
+  - "Leo Cassarani"
 tags:
   - Rails
 ---

--- a/source/blog/2013-04-11-two-months-at-unboxed.html.markdown
+++ b/source/blog/2013-04-11-two-months-at-unboxed.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-04-11 15:53:00 UTC"
 published: true
 title: "Two Months at Unboxed!"
-author: "Tillie McCarthy"
+authors:
+  - "Tillie McCarthy"
 tags:
   - Culture
 

--- a/source/blog/2013-04-12-dev-links.html.markdown
+++ b/source/blog/2013-04-12-dev-links.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-04-12 13:40:00 UTC"
 published: true
 title: "Dev Links"
-author: "Grant Speelman"
+authors:
+  - "Grant Speelman"
 tags:
   - Rails
 ---

--- a/source/blog/2013-04-26-almost-first-of-mays-newsletter.html.markdown
+++ b/source/blog/2013-04-26-almost-first-of-mays-newsletter.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-04-26 12:36:00 UTC"
 published: true
 title: "Almost April's last newsletter"
-author: Tom ten Thij
+authors:
+  - Tom ten Thij
 tags: 
   - Rails
 main_image: ""

--- a/source/blog/2013-05-03-the-week-preceding-early-may-bank-holiday.html.markdown
+++ b/source/blog/2013-05-03-the-week-preceding-early-may-bank-holiday.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-05-03 14:18:00 UTC"
 published: true
 title: "The Week Preceding Early May Bank Holiday"
-author: "Matt Peperell"
+authors:
+  - "Matt Peperell"
 tags:
   - Rails
 ---

--- a/source/blog/2013-05-10-agile-metrics.html.markdown
+++ b/source/blog/2013-05-10-agile-metrics.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-05-10 09:00:00 UTC"
 published: true
 title: "Agile metrics"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
 ---

--- a/source/blog/2013-05-10-its-life-jim-but-not-as-we-know-it.html.markdown
+++ b/source/blog/2013-05-10-its-life-jim-but-not-as-we-know-it.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-05-10 16:55:00 UTC"
 published: true
 title: "It's life, Jim, but not as we know it"
-author: "Jolyon Pawlyn"
+authors:
+  - "Jolyon Pawlyn"
 tags:
   - Rails
 ---

--- a/source/blog/2013-05-15-max-attempts-for-a-single-delayed_job-job.html.markdown
+++ b/source/blog/2013-05-15-max-attempts-for-a-single-delayed_job-job.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-05-15 09:32:00 UTC"
 published: true
 title: "Max attempts for a single delayed_job Job"
-author: "Pawel Janiak"
+authors:
+  - "Pawel Janiak"
 tags:
   - Rails
 ---

--- a/source/blog/2013-05-17-newsletter-of-brevity.html.markdown
+++ b/source/blog/2013-05-17-newsletter-of-brevity.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-05-17 13:18:00 UTC"
 published: true
 title: "Newsletter of Brevity"
-author: "Ben Wong"
+authors:
+  - "Ben Wong"
 tags:
   - Rails
   - Design

--- a/source/blog/2013-05-24-dev-newsletter-week-21-2013.html.markdown
+++ b/source/blog/2013-05-24-dev-newsletter-week-21-2013.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-05-24 16:59:00 UTC"
 published: true
 title: "Dev Newsletter (Week 21, 2013)"
-author: Attila Gyorffy
+authors:
+  - Attila Gyorffy
 tags: 
   - Design
   - Rails

--- a/source/blog/2013-05-31-the-week-in-which-arrested-development-came-back.html.markdown
+++ b/source/blog/2013-05-31-the-week-in-which-arrested-development-came-back.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-05-31 11:13:00 UTC"
 published: true
 title: "The Week In Which Arrested Development Came Back"
-author: "Carl Whittaker"
+authors:
+  - "Carl Whittaker"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-06-07-pre-summer-dev-newsletter-2-weeks-to-go.html.markdown
+++ b/source/blog/2013-06-07-pre-summer-dev-newsletter-2-weeks-to-go.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-06-07 14:05:00 UTC"
 published: true
 title: "Pre Summer Dev Newsletter (2 weeks to go)"
-author: "Seb Jacobs"
+authors:
+  - "Seb Jacobs"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-06-17-something-wicked-this-way-comes.html.markdown
+++ b/source/blog/2013-06-17-something-wicked-this-way-comes.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-06-17 15:17:00 UTC"
 published: true
 title: "Something wicked this way comes"
-author: "Robert Pataki"
+authors:
+  - "Robert Pataki"
 tags:
   - Design
   - Rails

--- a/source/blog/2013-06-21-all-this-has-happened-before-and-all-this-will-happen-again.html.markdown
+++ b/source/blog/2013-06-21-all-this-has-happened-before-and-all-this-will-happen-again.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-06-21 13:45:00 UTC"
 published: true
 title: "All this has happened before, and all this will happen again"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-06-28-all-of-the-new-shiny-code.html.markdown
+++ b/source/blog/2013-06-28-all-of-the-new-shiny-code.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-06-28 16:05:00 UTC"
 published: true
 title: "All of the new shiny code"
-author: "Andrew Mitchell"
+authors:
+  - "Andrew Mitchell"
 tags:
   - Design
   - Rails

--- a/source/blog/2013-07-05-happy-friday.html.markdown
+++ b/source/blog/2013-07-05-happy-friday.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-07-05 07:33:00 UTC"
 published: true
 title: "Happy Friday!"
-author: "Elizabeth Curson"
+authors:
+  - "Elizabeth Curson"
 tags:
   - Rails
   - Testing

--- a/source/blog/2013-07-12-must-read-dev-newsletter.html.markdown
+++ b/source/blog/2013-07-12-must-read-dev-newsletter.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-07-12 15:00:00 UTC"
 published: true
 title: "Must Read Dev Newsletter"
-author: "Grant Speelman"
+authors:
+  - "Grant Speelman"
 tags:
   - Rails
   - Testing

--- a/source/blog/2013-07-19-cape-town-curator.html.markdown
+++ b/source/blog/2013-07-19-cape-town-curator.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-07-19 14:00:00 UTC"
 published: true
 title: "Happy Ashes!"
-author: "Tyrone Toplis"
+authors:
+  - "Tyrone Toplis"
 tags:
   - Rails
   - Design

--- a/source/blog/2013-07-26-by-george-a-newsletter-what-ho.html.markdown
+++ b/source/blog/2013-07-26-by-george-a-newsletter-what-ho.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-07-26 08:33:00 UTC"
 published: true
 title: "By George! A newsletter! What-ho!"
-author: "Andrew Mitchell"
+authors:
+  - "Andrew Mitchell"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-08-02-undefined-local-variable-or-method-title.html.markdown
+++ b/source/blog/2013-08-02-undefined-local-variable-or-method-title.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-08-02 13:05:00 UTC"
 published: true
 title: "Undefined local variable or method 'title'"
-author: "Tom Sabin"
+authors:
+  - "Tom Sabin"
 tags:
   - Rails
 ---

--- a/source/blog/2013-08-09-dev-newsletter-9th-august.html.markdown
+++ b/source/blog/2013-08-09-dev-newsletter-9th-august.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-08-09 16:35:00 UTC"
 published: true
 title: "Dev Newsletter, 9th August"
-author: "Leo Cassarani"
+authors:
+  - "Leo Cassarani"
 tags:
   - Rails
   - Design

--- a/source/blog/2013-08-23-belated-newsletter.html.markdown
+++ b/source/blog/2013-08-23-belated-newsletter.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-08-23 12:00:00 UTC"
 published: true
 title: "Belated Newsletter"
-author: "Ben Janecke"
+authors:
+  - "Ben Janecke"
 tags:
   - Rails
   - Design

--- a/source/blog/2013-08-30-on-the-29th-anniversary-of-space-shuttle-discoverys-maiden-flight.html.markdown
+++ b/source/blog/2013-08-30-on-the-29th-anniversary-of-space-shuttle-discoverys-maiden-flight.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-08-30 10:00:00 UTC"
 published: true
 title: "On the 29th anniversary of Space Shuttle Discovery's maiden flight"
-author: "Matt Peperell"
+authors:
+  - "Matt Peperell"
 tags:
   - Agile
   - Rails

--- a/source/blog/2013-09-06-developer-newsletter-6th-september.html.markdown
+++ b/source/blog/2013-09-06-developer-newsletter-6th-september.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-09-06 12:17:00 UTC"
 published: true
 title: "Developer Newsletter, 6th September"
-author: "Attila Gyorffy"
+authors:
+  - "Attila Gyorffy"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-09-13-programmers-day-newsletter.html.markdown
+++ b/source/blog/2013-09-13-programmers-day-newsletter.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-09-13 15:03:00 UTC"
 published: true
 title: "Programmers' day newsletter"
-author: "Tom ten Thij"
+authors:
+  - "Tom ten Thij"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-09-20-developer-newsletter-20th-september.html.markdown
+++ b/source/blog/2013-09-20-developer-newsletter-20th-september.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-09-20 14:48:00 UTC"
 published: true
 title: "Developer Newsletter, 20th September"
-author: "Seb Jacobs"
+authors:
+  - "Seb Jacobs"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-09-27-dev-newsletter-27th-september.html.markdown
+++ b/source/blog/2013-09-27-dev-newsletter-27th-september.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-09-27 12:50:00 UTC"
 published: true
 title: "Dev Newsletter: 27th September"
-author: "Melinda Seckington"
+authors:
+  - "Melinda Seckington"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-10-04-developer-newsletter-4th-october.html.markdown
+++ b/source/blog/2013-10-04-developer-newsletter-4th-october.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-10-04 11:59:00 UTC"
 published: true
 title: "Developer Newsletter, 4th October"
-author: "Wilhelm Kirschbaum"
+authors:
+  - "Wilhelm Kirschbaum"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-10-11-the-shortest-of-newsletters-in-the-history-of-newsletters.html.markdown
+++ b/source/blog/2013-10-11-the-shortest-of-newsletters-in-the-history-of-newsletters.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-10-11 08:05:00 UTC"
 published: true
 title: "The best dev newsletter you will read today "
-author: "Elizabeth Curson"
+authors:
+  - "Elizabeth Curson"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-10-18-the-blog-post-title.html.markdown
+++ b/source/blog/2013-10-18-the-blog-post-title.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-10-18 10:29:00 UTC"
 published: true
 title: "The blog post title!"
-author: "Elizabeth Curson"
+authors:
+  - "Elizabeth Curson"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-10-25-how-do-you-like-them-links.html.markdown
+++ b/source/blog/2013-10-25-how-do-you-like-them-links.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-10-25 10:33:00 UTC"
 published: true
 title: "How do you like them links?!"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-11-04-post-halloween-developer-newsletter-4th-october.html.markdown
+++ b/source/blog/2013-11-04-post-halloween-developer-newsletter-4th-october.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-11-04 15:02:00 UTC"
 published: true
 title: "Post Halloween Developer Newsletter - 4th October"
-author: "Richard Archer"
+authors:
+  - "Richard Archer"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-11-11-the-short-and-late-one.html.markdown
+++ b/source/blog/2013-11-11-the-short-and-late-one.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-11-11 12:52:00 UTC"
 published: true
 title: "The short and late one"
-author: "Pawel Janiak"
+authors:
+  - "Pawel Janiak"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-11-15-november-newsletter.html.markdown
+++ b/source/blog/2013-11-15-november-newsletter.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-11-15 14:00:00 UTC"
 published: true
 title: "November Newsletter"
-author: "Tom Sabin"
+authors:
+  - "Tom Sabin"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-11-22-dev-news-for-friday.html.markdown
+++ b/source/blog/2013-11-22-dev-news-for-friday.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-11-22 15:38:00 UTC"
 published: true
 title: "Dev News for Friday"
-author: "Grant Speelman"
+authors:
+  - "Grant Speelman"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-11-29-the-not-as-short-as-some-and-not-late-at-all-one.html.markdown
+++ b/source/blog/2013-11-29-the-not-as-short-as-some-and-not-late-at-all-one.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-11-29 15:04:00 UTC"
 published: true
 title: "The Not As Short As Some and Not Late At All One"
-author: "Ben Wong"
+authors:
+  - "Ben Wong"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-12-06-bootstrap-skepticism-and-a-git-tool.html.markdown
+++ b/source/blog/2013-12-06-bootstrap-skepticism-and-a-git-tool.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-12-06 13:29:00 UTC"
 published: true
 title: "Bootstrap, skepticism and a git tool"
-author: "Pawel Janiak"
+authors:
+  - "Pawel Janiak"
 tags:
   - Rails
   - Agile

--- a/source/blog/2013-12-19-why-failure-isnt-bad-as-long-as-you-learn.html.markdown
+++ b/source/blog/2013-12-19-why-failure-isnt-bad-as-long-as-you-learn.html.markdown
@@ -2,7 +2,8 @@
 date: "2013-12-19 13:42:00 UTC"
 published: true
 title: "Why failure isn’t bad, as long as you learn"
-author: "Glenn Smith"
+authors:
+  - "Glenn Smith"
 tags:
   - Innovation
   - Agile

--- a/source/blog/2013-12-20-the-devmas-newsletter.html.markdown
+++ b/source/blog/2013-12-20-the-devmas-newsletter.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2013-12-20 16:22:00 UTC"
 published: true
 title: "The Devmas Newsletter "
-author: "Andrew Mitchell"
+authors:
+  - "Andrew Mitchell"
 tags:
   - Design
   - Rails

--- a/source/blog/2014-01-10-happy-new-year-unboxedians.html.markdown
+++ b/source/blog/2014-01-10-happy-new-year-unboxedians.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-01-10 12:25:00 UTC"
 published: true
 title: "Happy New Year Unboxedians and commiserations on the ashes"
-author: "Tyrone Toplis"
+authors:
+  - "Tyrone Toplis"
 tags:
   - Rails
 ---

--- a/source/blog/2014-01-31-how-dot-voting-can-reveal-the-unexpected.html.markdown
+++ b/source/blog/2014-01-31-how-dot-voting-can-reveal-the-unexpected.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-01-31 13:49:00 UTC"
 published: true
 title: "How dot voting can reveal the unexpected"
-author: "Glenn Smith"
+authors:
+  - "Glenn Smith"
 tags:
   - Agile
 ---

--- a/source/blog/2014-01-31-the-most-anticipated-newsletter-of-the-year.html.markdown
+++ b/source/blog/2014-01-31-the-most-anticipated-newsletter-of-the-year.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-01-31 13:55:00 UTC"
 published: true
 title: "The most anticipated newsletter of the year"
-author: "Karl Entwistle"
+authors:
+  - "Karl Entwistle"
 tags:
   - Rails
 ---

--- a/source/blog/2014-02-06-native-chrome-apps-on-mobile.html.markdown
+++ b/source/blog/2014-02-06-native-chrome-apps-on-mobile.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-02-06 08:54:00 UTC"
 published: true
 title: "Native Chrome apps on mobile"
-author: "Henry Turner"
+authors:
+  - "Henry Turner"
 tags:
   - Innovation
 

--- a/source/blog/2014-02-10-migrating-data-games-on-the-web-platform-better-calendars-and-active-record-relation-counting.html.markdown
+++ b/source/blog/2014-02-10-migrating-data-games-on-the-web-platform-better-calendars-and-active-record-relation-counting.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-02-10 13:23:00 UTC"
 published: true
 title: "Migrating data, games on the web platform, better calendars and active record relation counting."
-author: "Ben Janecke"
+authors:
+  - "Ben Janecke"
 tags:
   - Rails
 ---

--- a/source/blog/2014-03-05-haskell-at-the-london-code-dojo.html.markdown
+++ b/source/blog/2014-03-05-haskell-at-the-london-code-dojo.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-03-05 19:10:00 UTC"
 published: true
 title: "Haskell at the London Code Dojo"
-author: "Henry Turner"
+authors:
+  - "Henry Turner"
 tags:
   - Innovation
 

--- a/source/blog/2014-03-07-the-cat-experience.html.markdown
+++ b/source/blog/2014-03-07-the-cat-experience.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-03-07 15:00:00 UTC"
 published: true
 title: "The CAT experience"
-author: "Priyanka Sushil"
+authors:
+  - "Priyanka Sushil"
 tags:
   - Testing
 ---

--- a/source/blog/2014-03-10-because-friday-newsletters-are-overrated.html.markdown
+++ b/source/blog/2014-03-10-because-friday-newsletters-are-overrated.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-03-10 07:21:00 UTC"
 published: true
 title: "Because Friday newsletters are overrated"
-author: "Richard Archer"
+authors:
+  - "Richard Archer"
 tags:
   - Culture
 

--- a/source/blog/2014-04-15-opensslsslsslerror-certificate-verify-failed.html.markdown
+++ b/source/blog/2014-04-15-opensslsslsslerror-certificate-verify-failed.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-04-15 14:28:00 UTC"
 published: true
 title: "OpenSSL::SSL::SSLError: certificate verify failed "
-author: "Karl Entwistle"
+authors:
+  - "Karl Entwistle"
 tags:
   - Rails
 ---

--- a/source/blog/2014-04-22-the-r-in-lean.html.markdown
+++ b/source/blog/2014-04-22-the-r-in-lean.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-04-22 14:38:00 UTC"
 published: true
 title: "The \"r\" in lean"
-author: "Martyn Evans"
+authors:
+  - "Martyn Evans"
 tags:
   - Lean
   - Design

--- a/source/blog/2014-04-23-innovation-days-developing-in-meteor.html.markdown
+++ b/source/blog/2014-04-23-innovation-days-developing-in-meteor.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-04-23 11:19:00 UTC"
 published: true
 title: "Innovation days - developing in Meteor"
-author: "Tom Sabin"
+authors:
+  - "Tom Sabin"
 tags:
   - Innovation
   - Rails

--- a/source/blog/2014-05-19-first-steps-with-cordova-phonegap.html.markdown
+++ b/source/blog/2014-05-19-first-steps-with-cordova-phonegap.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-05-19 13:51:00 UTC"
 published: true
 title: "First steps with Cordova / PhoneGap"
-author: "Veronika Hillebrand"
+authors:
+  - "Veronika Hillebrand"
 tags:
   - Design
   - Rails

--- a/source/blog/2014-05-20-dev_toolboxpack.html.markdown
+++ b/source/blog/2014-05-20-dev_toolboxpack.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-05-20 11:58:00 UTC"
 published: true
 title: "dev_toolbox.pack()"
-author: "Tom Sabin"
+authors:
+  - "Tom Sabin"
 tags:
   - Innovation
 

--- a/source/blog/2014-06-03-dever-say-dever-again.html.markdown
+++ b/source/blog/2014-06-03-dever-say-dever-again.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-06-03 10:22:00 UTC"
 published: true
 title: "Dever say Dever again"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
   - Agile

--- a/source/blog/2014-06-07-jquery-uk-conference-2014.html.markdown
+++ b/source/blog/2014-06-07-jquery-uk-conference-2014.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-06-07 18:30:00 UTC"
 published: true
 title: "jQuery UK 2014"
-author: "Tom Sabin"
+authors:
+  - "Tom Sabin"
 tags:
   - Rails
 ---

--- a/source/blog/2014-06-13-is-agile-testing-worth-it.html.markdown
+++ b/source/blog/2014-06-13-is-agile-testing-worth-it.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-06-13 10:08:00 UTC"
 published: true
 title: "Is agile testing worth it?"
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags: 
   - Agile
   - Rails

--- a/source/blog/2014-06-13-you-only-dev-twice.html.markdown
+++ b/source/blog/2014-06-13-you-only-dev-twice.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-06-13 11:42:00 UTC"
 published: true
 title: "You only dev twice"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-06-20-three-times-a-dev.html.markdown
+++ b/source/blog/2014-06-20-three-times-a-dev.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-06-20 13:30:00 UTC"
 published: true
 title: "Three times a dev"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-06-27-spread-to-the-four-corners-of-the-dev.html.markdown
+++ b/source/blog/2014-06-27-spread-to-the-four-corners-of-the-dev.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-06-27 12:30:00 UTC"
 published: true
 title: "Spread to the four corners of the dev"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-07-04-workin-dev-to-five-what-a-way-to-make-a-livin.html.markdown
+++ b/source/blog/2014-07-04-workin-dev-to-five-what-a-way-to-make-a-livin.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-07-04 12:30:00 UTC"
 published: true
 title: "Workin' dev to five, what a way to make a livin'"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-07-11-six-of-one-half-a-dev-of-another.html.markdown
+++ b/source/blog/2014-07-11-six-of-one-half-a-dev-of-another.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-07-11 14:10:00 UTC"
 published: true
 title: "Six of one, half a dev of another"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-07-18-the-seven-deadly-devs.html.markdown
+++ b/source/blog/2014-07-18-the-seven-deadly-devs.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-07-18 13:30:00 UTC"
 published: true
 title: "The seven deadly devs"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-07-25-to-have-dev-over-the-eight.html.markdown
+++ b/source/blog/2014-07-25-to-have-dev-over-the-eight.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-07-25 13:30:00 UTC"
 published: true
 title: "To have dev over the eight"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-07-31-a-ruby-plated-breakfast.html.markdown
+++ b/source/blog/2014-07-31-a-ruby-plated-breakfast.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-07-31 13:42:00 UTC"
 published: true
 title: "A Ruby-plated breakfast"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Rails
 ---

--- a/source/blog/2014-08-01-the-dev-o-nine-tails.html.markdown
+++ b/source/blog/2014-08-01-the-dev-o-nine-tails.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-08-01 13:30:00 UTC"
 published: true
 title: "The dev o' nine tails"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-08-06-lean-machine.html.markdown
+++ b/source/blog/2014-08-06-lean-machine.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-08-06 14:50:00 UTC"
 published: true
 title: "Lean Machine"
-author: "Chris Carter"
+authors:
+  - "Chris Carter"
 tags:
   - Lean
 ---

--- a/source/blog/2014-08-08-ten-to-the-dev.html.markdown
+++ b/source/blog/2014-08-08-ten-to-the-dev.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-08-08 13:40:00 UTC"
 published: true
 title: "Ten to the dev"
-author: "Chris Carter"
+authors:
+  - "Chris Carter"
 tags:
   - Rails
 ---

--- a/source/blog/2014-08-12-the-agile-lego-village.html.markdown
+++ b/source/blog/2014-08-12-the-agile-lego-village.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-08-12 14:33:00 UTC"
 published: true
 title: "The Agile LEGO village"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
 ---

--- a/source/blog/2014-08-22-ubxddev-vol31.html.markdown
+++ b/source/blog/2014-08-22-ubxddev-vol31.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-08-22 13:30:00 UTC"
 published: true
 title: "UBXDDEV Vol3.1"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-08-29-ubxddev-vol-32.html.markdown
+++ b/source/blog/2014-08-29-ubxddev-vol-32.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-08-29 13:30:00 UTC"
 published: true
 title: "UBXDDEV Vol. 3.2"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-09-02-only-fools-rush-in.html.markdown
+++ b/source/blog/2014-09-02-only-fools-rush-in.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-09-02 09:44:00 UTC"
 published: true
 title: "Only fools rush in"
-author: "Pedro Moreira"
+authors:
+  - "Pedro Moreira"
 tags:
   - Rails
 

--- a/source/blog/2014-09-05-ubxddev-vol-33.html.markdown
+++ b/source/blog/2014-09-05-ubxddev-vol-33.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-09-05 13:30:00 UTC"
 published: true
 title: "UBXDDEV Vol. 3.3"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-09-09-people-matter-most.html.markdown
+++ b/source/blog/2014-09-09-people-matter-most.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-09-09 15:52:00 UTC"
 published: true
 title: "People Matter Most!"
-author: "Claire Kemp"
+authors:
+  - "Claire Kemp"
 tags:
   - Agile
 ---

--- a/source/blog/2014-09-12-the-outsourcing-dilemma.html.markdown
+++ b/source/blog/2014-09-12-the-outsourcing-dilemma.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-09-12 12:28:00 UTC"
 published: true
 title: "The Outsourcing Dilemma "
-author: "Carrie Bedingfield"
+authors:
+  - "Carrie Bedingfield"
 tags:
   - Agile
 ---

--- a/source/blog/2014-09-12-ubxddev-vol-34.html.markdown
+++ b/source/blog/2014-09-12-ubxddev-vol-34.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-09-12 13:30:00 UTC"
 published: true
 title: "UBXDDEV Vol. 3.4"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-09-18-summer-unboxin-had-me-a-blast.html.markdown
+++ b/source/blog/2014-09-18-summer-unboxin-had-me-a-blast.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-09-18 14:22:00 UTC"
 published: true
 title: "Summer Unboxin' had me a blast"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Culture
   - Innovation

--- a/source/blog/2014-09-19-ubxddev-vol-35.html.markdown
+++ b/source/blog/2014-09-19-ubxddev-vol-35.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-09-19 13:45:00 UTC"
 published: true
 title: "UBXDDEV Vol. 3.5"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-09-26-rapid-ui-prototyping-and-getting-on-the-rails.html.markdown
+++ b/source/blog/2014-09-26-rapid-ui-prototyping-and-getting-on-the-rails.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-09-26 15:33:00 UTC"
 published: true
 title: "Rapid UI prototyping and getting on the Rails"
-author: "Martyn Evans"
+authors:
+  - "Martyn Evans"
 tags:
   - Lean
   - Innovation

--- a/source/blog/2014-09-26-ubxddev-vol-3-6.html.markdown
+++ b/source/blog/2014-09-26-ubxddev-vol-3-6.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-09-26 13:30:00 UTC"
 published: true
 title: "UBXDDEV Vol. 3.6"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-10-03-ubxddev-vol-37.html.markdown
+++ b/source/blog/2014-10-03-ubxddev-vol-37.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-10-03 13:30:00 UTC"
 published: true
 title: "UBXDDEV Vol. 3.7"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-10-10-diving-into-the-front-end.html.markdown
+++ b/source/blog/2014-10-10-diving-into-the-front-end.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-10-10 10:46:00 UTC"
 published: true
 title: "Diving Into the Front End"
-author: "Neil Van Beinum"
+authors:
+  - "Neil Van Beinum"
 tags:
   - Rails
   - Design

--- a/source/blog/2014-10-10-filling-gaps.html.markdown
+++ b/source/blog/2014-10-10-filling-gaps.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-10-10 11:47:00 UTC"
 published: true
 title: "Filling Gaps"
-author: "Martyn Evans"
+authors:
+  - "Martyn Evans"
 tags:
   - Lean
 ---

--- a/source/blog/2014-10-10-ubxddev-vol-38.html.markdown
+++ b/source/blog/2014-10-10-ubxddev-vol-38.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-10-10 13:30:00 UTC"
 published: true
 title: "UBXDDEV Vol. 3.8"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-10-13-cognitive-bias-product-management-and-you.html.markdown
+++ b/source/blog/2014-10-13-cognitive-bias-product-management-and-you.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-10-13 10:55:00 UTC"
 published: true
 title: "Cognitive Bias, Product Management and you"
-author: "Carlo Kruger"
+authors:
+  - "Carlo Kruger"
 tags:
   - Agile
   - Design

--- a/source/blog/2014-10-17-ubxddev-vol-39.html.markdown
+++ b/source/blog/2014-10-17-ubxddev-vol-39.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-10-17 13:30:00 UTC"
 published: true
 title: "UBXDDEV Vol. 3.9"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-10-22-tactile-agile-for-introverts.html.markdown
+++ b/source/blog/2014-10-22-tactile-agile-for-introverts.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-10-22 16:58:00 UTC"
 published: true
 title: "Tactile agile for Introverts"
-author: "Claire Kemp"
+authors:
+  - "Claire Kemp"
 tags:
   - Agile
   - Culture

--- a/source/blog/2014-10-24-ubxddev-vol-3-10.html.markdown
+++ b/source/blog/2014-10-24-ubxddev-vol-3-10.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-10-24 13:30:00 UTC"
 published: true
 title: "UBXDDEV Vol. 3.10"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-10-27-digital-leaders-discover-the-new-rules-of-outsourcing-agile-teams-session.html.markdown
+++ b/source/blog/2014-10-27-digital-leaders-discover-the-new-rules-of-outsourcing-agile-teams-session.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-10-27 12:08:00 UTC"
 published: true
 title: "Event: Digital leaders discover the 'new rules' of outsourcing - Agile Teams session"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
 ---

--- a/source/blog/2014-10-31-ubxddev-vol-3-11.html.markdown
+++ b/source/blog/2014-10-31-ubxddev-vol-3-11.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-10-31 14:30:00 UTC"
 published: true
 title: "UBXDDEV Vol. 3.11"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Rails
 ---

--- a/source/blog/2014-11-14-unboxed-roundup-our-links-for-w-c-10th-november-2014.html.markdown
+++ b/source/blog/2014-11-14-unboxed-roundup-our-links-for-w-c-10th-november-2014.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-11-14 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 10th November 2014"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2014-11-18-what-s-there-to-know-about-outsourcing.html.markdown
+++ b/source/blog/2014-11-18-what-s-there-to-know-about-outsourcing.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-11-18 12:03:00 UTC"
 published: true
 title: "Event: What is there to know about outsourcing?"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
   - Culture

--- a/source/blog/2014-11-21-unboxed-roundup-our-links-for-w-c-17th-november-2014.html.markdown
+++ b/source/blog/2014-11-21-unboxed-roundup-our-links-for-w-c-17th-november-2014.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-11-21 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 17th November 2014"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2014-11-24-digital-webinar-series-communication-ceremonies.html.markdown
+++ b/source/blog/2014-11-24-digital-webinar-series-communication-ceremonies.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-11-24 10:58:00 UTC"
 published: true
 title: "Webinar: Communication Ceremonies"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
   - Culture

--- a/source/blog/2014-11-28-unboxed-roundup-our-links-for-w-c-24th-november-2014.html.markdown
+++ b/source/blog/2014-11-28-unboxed-roundup-our-links-for-w-c-24th-november-2014.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-11-28 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 24th November 2014"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2014-12-05-digital-leaders-webinar-getting-to-beta.html.markdown
+++ b/source/blog/2014-12-05-digital-leaders-webinar-getting-to-beta.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-12-05 11:26:00 UTC"
 published: true
 title: "Webinar: Getting to Beta"
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags: 
   - Agile
   - Culture

--- a/source/blog/2014-12-05-unboxed-roundup-our-links-for-w-c-1st-decemnber-2014.html.markdown
+++ b/source/blog/2014-12-05-unboxed-roundup-our-links-for-w-c-1st-decemnber-2014.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-12-05 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 1st December 2014"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2014-12-12-unboxed-roundup-our-links-for-w-c-8th-december-2014.html.markdown
+++ b/source/blog/2014-12-12-unboxed-roundup-our-links-for-w-c-8th-december-2014.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-12-12 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 8th December 2014"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2014-12-16-being-lean-in-the-nhs.html.markdown
+++ b/source/blog/2014-12-16-being-lean-in-the-nhs.html.markdown
@@ -2,7 +2,8 @@
 date: "2014-12-16 18:11:00 UTC"
 published: true
 title: Being lean in the NHS
-author: Martyn Evans
+authors:
+  - Martyn Evans
 tags: 
   - Agile
   - Lean

--- a/source/blog/2014-12-19-unboxed-roundup-our-links-for-w-c-15th-december-2014.html.markdown
+++ b/source/blog/2014-12-19-unboxed-roundup-our-links-for-w-c-15th-december-2014.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2014-12-19 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 15th December 2014"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-01-09-unboxed-roundup-our-links-for-w-c-5th-january-2015.html.markdown
+++ b/source/blog/2015-01-09-unboxed-roundup-our-links-for-w-c-5th-january-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-01-09 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 5th January 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-01-16-unboxed-roundup-our-links-for-w-c-12th-january-2015.html.markdown
+++ b/source/blog/2015-01-16-unboxed-roundup-our-links-for-w-c-12th-january-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-01-16 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 12th January 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-01-20-how-to-prioritise-a-blocked-portfolio-of-digital-products.html.markdown
+++ b/source/blog/2015-01-20-how-to-prioritise-a-blocked-portfolio-of-digital-products.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-01-20 11:30:00 UTC"
 published: true
 title: "How to prioritise a blocked portfolio of digital products"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
 

--- a/source/blog/2015-01-23-unboxed-roundup-our-links-for-w-c-19th-january-2015.html.markdown
+++ b/source/blog/2015-01-23-unboxed-roundup-our-links-for-w-c-19th-january-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-01-23 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 19th January 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-01-26-on-being-a-remote-worker.html.markdown
+++ b/source/blog/2015-01-26-on-being-a-remote-worker.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-01-26 11:45:00 UTC"
 published: true
 title: "On being a remote worker"
-author: "Pawel Janiak"
+authors:
+  - "Pawel Janiak"
 tags:
   - Culture
 

--- a/source/blog/2015-01-26-sending-smime-encrypted-emails-with-action-mailer.html.markdown
+++ b/source/blog/2015-01-26-sending-smime-encrypted-emails-with-action-mailer.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-01-26 01:50:00 UTC"
 published: true
 title: "Sending S/MIME encrypted emails with Action Mailer"
-author: "Andrew White"
+authors:
+  - "Andrew White"
 tags:
   - Rails
 ---

--- a/source/blog/2015-01-27-webinar-90-days-to-transform-a-stuck-digital-product-that-has-to-succeed-9c47e9a9-2a9b-4bf5-83ab-b96fe13e1908.html.markdown
+++ b/source/blog/2015-01-27-webinar-90-days-to-transform-a-stuck-digital-product-that-has-to-succeed-9c47e9a9-2a9b-4bf5-83ab-b96fe13e1908.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-01-27 17:38:00 UTC"
 published: true
 title: "Webinar: 90 days to transform a ‘stuck’ digital product that HAS to succeed..."
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
 ---

--- a/source/blog/2015-01-30-unboxed-roundup-our-links-for-w-c-26th-january-2015.html.markdown
+++ b/source/blog/2015-01-30-unboxed-roundup-our-links-for-w-c-26th-january-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-01-30 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 26th January 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-02-06-unboxed-roundup-our-links-for-w-c-2nd-february-2015.html.markdown
+++ b/source/blog/2015-02-06-unboxed-roundup-our-links-for-w-c-2nd-february-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-02-06 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 2nd February 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-02-11-deciding-how-to-deliver-your-prioritised-project-portfolio.html.markdown
+++ b/source/blog/2015-02-11-deciding-how-to-deliver-your-prioritised-project-portfolio.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-02-11 13:48:00 UTC"
 published: true
 title: "Deciding how to deliver your prioritised project portfolio"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-02-13-unboxed-roundup-our-links-for-w-c-9th-february-2015.html.markdown
+++ b/source/blog/2015-02-13-unboxed-roundup-our-links-for-w-c-9th-february-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-02-13 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 9th February 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-02-20-unboxed-roundup-our-links-for-w-c-16th-february-2015.html.markdown
+++ b/source/blog/2015-02-20-unboxed-roundup-our-links-for-w-c-16th-february-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-02-20 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 16th February 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-02-26-digital-healthcare-roundtable-session.html.markdown
+++ b/source/blog/2015-02-26-digital-healthcare-roundtable-session.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-02-26 13:04:00 UTC"
 published: true
 title: "Roundtable: Digital Healthcare"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-02-27-unboxed-roundup-our-links-for-w-c-23rd-february-2015.html.markdown
+++ b/source/blog/2015-02-27-unboxed-roundup-our-links-for-w-c-23rd-february-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-02-27 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 23rd February 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-03-02-webinar-spanning-the-rift-advice-for-waterfall-organisations-running-agile-projects.html.markdown
+++ b/source/blog/2015-03-02-webinar-spanning-the-rift-advice-for-waterfall-organisations-running-agile-projects.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-03-02 13:30:00 UTC"
 published: true
 title: "Webinar: Spanning the rift - Advice for waterfall organisations running Agile projects"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-03-03-guest-blog-a-technical-guide-to-mobile-usability-testing.html.markdown
+++ b/source/blog/2015-03-03-guest-blog-a-technical-guide-to-mobile-usability-testing.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-03-03 10:00:00 UTC"
 published: true
 title: "Guest blog: A technical guide to mobile usability testing"
-author: "Rian Van Der Merwe"
+authors:
+  - "Rian Van Der Merwe"
 tags:
   - Testing
 

--- a/source/blog/2015-03-06-unboxed-roundup-our-links-for-w-c-2nd-march-2015.html.markdown
+++ b/source/blog/2015-03-06-unboxed-roundup-our-links-for-w-c-2nd-march-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-03-06 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 2nd March 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-03-06-webinar-take-developers-up-the-foodchain-why-how-to-include-developers-in-business-design-meetings-for-better-ideation.html.markdown
+++ b/source/blog/2015-03-06-webinar-take-developers-up-the-foodchain-why-how-to-include-developers-in-business-design-meetings-for-better-ideation.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-03-06 10:30:00 UTC"
 published: true
 title: "Webinar: Why & how to include developers in business & design meetings for better ideation"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-03-13-unboxed-roundup-our-links-for-w-c-9th-march-2015.html.markdown
+++ b/source/blog/2015-03-13-unboxed-roundup-our-links-for-w-c-9th-march-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-03-13 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 9th March 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-03-19-webinar-offshoring-agile-make-it-work-in-practice.html.markdown
+++ b/source/blog/2015-03-19-webinar-offshoring-agile-make-it-work-in-practice.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-03-19 10:30:00 UTC"
 published: true
 title: "Webinar: Offshoring Agile: Make it work in practice"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
 ---

--- a/source/blog/2015-03-20-unboxed-roundup-our-links-for-w-c-16th-march-2015.html.markdown
+++ b/source/blog/2015-03-20-unboxed-roundup-our-links-for-w-c-16th-march-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-03-20 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 16th March 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-03-27-unboxed-roundup-our-links-for-w-c-23rd-march-2015.html.markdown
+++ b/source/blog/2015-03-27-unboxed-roundup-our-links-for-w-c-23rd-march-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-03-27 14:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 23rd March 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-03-30-ubxd-event-kicking-the-cobwebs-out-of-your-stuck-digital-product-pipeline.html.markdown
+++ b/source/blog/2015-03-30-ubxd-event-kicking-the-cobwebs-out-of-your-stuck-digital-product-pipeline.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-03-30 12:00:00 UTC"
 published: true
 title: "Event: Kicking the cobwebs out of your stuck digital product pipeline"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
 ---

--- a/source/blog/2015-04-02-unboxed-roundup-our-links-for-w-c-30th-march-2015.html.markdown
+++ b/source/blog/2015-04-02-unboxed-roundup-our-links-for-w-c-30th-march-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-04-02 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 30th March 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-04-03-jquery-uk-2015.html.markdown
+++ b/source/blog/2015-04-03-jquery-uk-2015.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-04-03 12:40:00 UTC"
 published: true
 title: "jQuery UK 2015"
-author: "Neil Van Beinum"
+authors:
+  - "Neil Van Beinum"
 tags:
   - Design
 ---

--- a/source/blog/2015-04-10-unboxed-roundup-our-links-for-w-c-6th-april-2015.html.markdown
+++ b/source/blog/2015-04-10-unboxed-roundup-our-links-for-w-c-6th-april-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-04-10 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 6th April 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-04-17-unboxed-roundup-our-links-for-w-c-13th-april-2015.html.markdown
+++ b/source/blog/2015-04-17-unboxed-roundup-our-links-for-w-c-13th-april-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-04-17 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 13th April 2015"
-author: Murray Steele
+authors:
+  - Murray Steele
 tags: 
   - Culture
 main_image: ""

--- a/source/blog/2015-04-21-the-future-of-digital-products-and-how-we-ll-design-them-in-the-future.html.markdown
+++ b/source/blog/2015-04-21-the-future-of-digital-products-and-how-we-ll-design-them-in-the-future.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-04-21 09:15:00 UTC"
 published: true
 title: "The future of digital products and how we’ll design them in the future"
-author: "Leon Odey Knight"
+authors:
+  - "Leon Odey Knight"
 tags:
   - Design
 

--- a/source/blog/2015-04-24-unboxed-roundup-our-links-for-w-c-20th-april-2015.html.markdown
+++ b/source/blog/2015-04-24-unboxed-roundup-our-links-for-w-c-20th-april-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-04-24 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 20th April 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-04-24-unboxedis10-anniversary-song-countdown.html.markdown
+++ b/source/blog/2015-04-24-unboxedis10-anniversary-song-countdown.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-04-24 12:00:00 UTC"
 published: true
 title: "Unboxedis10 anniversary song countdown"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Culture
 

--- a/source/blog/2015-05-01-unboxed-roundup-our-links-for-w-c-27th-april-2015.html.markdown
+++ b/source/blog/2015-05-01-unboxed-roundup-our-links-for-w-c-27th-april-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-05-01 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 27th April 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-05-08-unboxed-roundup-our-links-for-w-c-4th-may-2015.html.markdown
+++ b/source/blog/2015-05-08-unboxed-roundup-our-links-for-w-c-4th-may-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-05-08 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 4th May 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-05-12-unstick-your-digital-products.html.markdown
+++ b/source/blog/2015-05-12-unstick-your-digital-products.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-05-12 16:32:00 UTC"
 published: true
 title: "Unstick your digital products"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
 

--- a/source/blog/2015-05-14-all-aboard.html.markdown
+++ b/source/blog/2015-05-14-all-aboard.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-05-14 16:30:00 UTC"
 published: true
 title: "All aboard"
-author: "Claire Kemp"
+authors:
+  - "Claire Kemp"
 tags:
   - Culture
   - Innovation

--- a/source/blog/2015-05-15-unboxed-roundup-our-links-for-w-c-11th-may-2015.html.markdown
+++ b/source/blog/2015-05-15-unboxed-roundup-our-links-for-w-c-11th-may-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-05-15 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: our links for w/c 11th May 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-05-19-sharing-your-local-development-server.html.markdown
+++ b/source/blog/2015-05-19-sharing-your-local-development-server.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-05-19 12:31:00 UTC"
 published: true
 title: "Sharing your local development server and setting up a local mail server"
-author: "Alan Thomas"
+authors:
+  - "Alan Thomas"
 tags:
   - Rails
 ---

--- a/source/blog/2015-05-21-media-roundtable-session-20th-may.html.markdown
+++ b/source/blog/2015-05-21-media-roundtable-session-20th-may.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-05-21 15:00:00 UTC"
 published: true
 title: "Roundtable: Leading the transition to Agile in established media companies"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-05-22-unboxed-roundup-our-links-for-w-c-18th-may-2015.html.markdown
+++ b/source/blog/2015-05-22-unboxed-roundup-our-links-for-w-c-18th-may-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-05-22 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 18th May 2015"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Culture
 ---

--- a/source/blog/2015-05-29-10-attributes-that-make-a-great-product-owner.html.markdown
+++ b/source/blog/2015-05-29-10-attributes-that-make-a-great-product-owner.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-05-29 10:44:00 UTC"
 published: true
 title: "10 Attributes that make a great product owner"
-author: "Alan Thomas"
+authors:
+  - "Alan Thomas"
 tags:
   - Agile
 

--- a/source/blog/2015-05-29-unboxed-roundup-our-links-for-w-c-25th-may-2015.html.markdown
+++ b/source/blog/2015-05-29-unboxed-roundup-our-links-for-w-c-25th-may-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-05-29 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 25th May 2015"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Culture
 

--- a/source/blog/2015-06-04-the-sausage-machine.html.markdown
+++ b/source/blog/2015-06-04-the-sausage-machine.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-06-04 15:00:00 UTC"
 published: true
 title: "The Sausage Machine"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-06-05-unboxed-roundup-our-links-for-w-c-1st-june-2015.html.markdown
+++ b/source/blog/2015-06-05-unboxed-roundup-our-links-for-w-c-1st-june-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-06-05 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 1st June 2015"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Culture
 

--- a/source/blog/2015-06-09-corporate-to-unboxed-a-project-manager-s-journey-to-scrum-master-part-1.html.markdown
+++ b/source/blog/2015-06-09-corporate-to-unboxed-a-project-manager-s-journey-to-scrum-master-part-1.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-06-09 08:30:00 UTC"
 published: true
 title: "Corporate to Unboxed, a Project Manager’s journey to Scrum Master - Part 1"
-author: "Matt Turrell"
+authors:
+  - "Matt Turrell"
 tags:
   - Culture
 

--- a/source/blog/2015-06-12-unboxed-roundup-our-links-for-w-c-8th-june-2015.html.markdown
+++ b/source/blog/2015-06-12-unboxed-roundup-our-links-for-w-c-8th-june-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-06-12 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 8th June 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-06-15-feature-based-benefits.html.markdown
+++ b/source/blog/2015-06-15-feature-based-benefits.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-06-15 09:00:00 UTC"
 published: true
 title: "Feature-based Benefits"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-06-19-unboxed-roundup-our-links-for-w-c-15th-june-2015.html.markdown
+++ b/source/blog/2015-06-19-unboxed-roundup-our-links-for-w-c-15th-june-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-06-19 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 15th June 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-06-22-how-does-the-product-owner-role-change-everything-in-software-delivery.html.markdown
+++ b/source/blog/2015-06-22-how-does-the-product-owner-role-change-everything-in-software-delivery.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-06-22 08:00:00 UTC"
 published: true
 title: "How does the Product Owner role change everything in software delivery?"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-06-24-corporate-to-unboxed-part-2-advanced-scrum-master-training.html.markdown
+++ b/source/blog/2015-06-24-corporate-to-unboxed-part-2-advanced-scrum-master-training.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-06-24 14:00:00 UTC"
 published: true
 title: "Corporate to Unboxed, Part 2 - Advanced Scrum Master Training"
-author: "Matt Turrell"
+authors:
+  - "Matt Turrell"
 tags:
   - Culture
 

--- a/source/blog/2015-06-25-webinar-speed-up-stakeholder-communication-and-sign-off.html.markdown
+++ b/source/blog/2015-06-25-webinar-speed-up-stakeholder-communication-and-sign-off.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-06-25 09:00:00 UTC"
 published: true
 title: "Webinar: Speed up stakeholder communication and sign off"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-06-26-unboxed-roundup-our-links-for-w-c-22nd-june-2015.html.markdown
+++ b/source/blog/2015-06-26-unboxed-roundup-our-links-for-w-c-22nd-june-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-06-26 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 22nd June 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-07-01-10-things-that-make-a-great-product-owner.html.markdown
+++ b/source/blog/2015-07-01-10-things-that-make-a-great-product-owner.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-07-01 16:53:00 UTC"
 published: true
 title: "10 things that make a great Product Owner"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
 

--- a/source/blog/2015-07-02-webinar-speed-up-problem-and-customer-validation.html.markdown
+++ b/source/blog/2015-07-02-webinar-speed-up-problem-and-customer-validation.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-07-02 16:15:00 UTC"
 published: true
 title: "Webinar: Speed up problem and customer validation"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-07-03-unboxed-roundup-our-links-for-w-c-29th-june-2015.html.markdown
+++ b/source/blog/2015-07-03-unboxed-roundup-our-links-for-w-c-29th-june-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-07-03 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 29th June 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-07-06-why-a-ux-er-and-a-developer-trumps-system-and-business-analysts.html.markdown
+++ b/source/blog/2015-07-06-why-a-ux-er-and-a-developer-trumps-system-and-business-analysts.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-07-06 08:30:00 UTC"
 published: true
 title: "Why a UX-er and a Developer trumps System and Business Analysts"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-07-10-unboxed-roundup-our-links-for-w-c-6th-july-2015.html.markdown
+++ b/source/blog/2015-07-10-unboxed-roundup-our-links-for-w-c-6th-july-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-07-10 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 6th July 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-07-13-are-you-managing-the-right-risks.html.markdown
+++ b/source/blog/2015-07-13-are-you-managing-the-right-risks.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-07-13 11:00:00 UTC"
 published: true
 title: "Are you managing the right risks?"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-07-17-unboxed-roundup-our-links-for-w-c-13th-july-2015.html.markdown
+++ b/source/blog/2015-07-17-unboxed-roundup-our-links-for-w-c-13th-july-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-07-17 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 13th July 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-07-24-unboxed-roundup-our-links-for-w-c-20th-july-2015.html.markdown
+++ b/source/blog/2015-07-24-unboxed-roundup-our-links-for-w-c-20th-july-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-07-24 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 20th July 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-07-28-why-should-you-have-a-zero-defect-strategy.html.markdown
+++ b/source/blog/2015-07-28-why-should-you-have-a-zero-defect-strategy.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-07-28 13:36:00 UTC"
 published: true
 title: "Why should you have a zero-defect strategy?"
-author: "Richard Stobart"
+authors:
+  - "Richard Stobart"
 tags:
   - Agile
 ---

--- a/source/blog/2015-07-31-unboxed-roundup-our-links-for-w-c-27th-july-2015.html.markdown
+++ b/source/blog/2015-07-31-unboxed-roundup-our-links-for-w-c-27th-july-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-07-31 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 27th July 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-08-04-what-is-the-definition-of-done.html.markdown
+++ b/source/blog/2015-08-04-what-is-the-definition-of-done.html.markdown
@@ -2,7 +2,8 @@
 date: '2015-08-04 15:30:00 UTC'
 published: true
 title: What is the definition of ‘done’?
-author: Richard Stobart
+authors:
+  - Richard Stobart
 main_image: /assets/images/prose/pedro.png
 tags:
   - Agile

--- a/source/blog/2015-08-07-communication-one-step-forward-two-steps-slack.html.markdown
+++ b/source/blog/2015-08-07-communication-one-step-forward-two-steps-slack.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-08-07 10:00:00 UTC"
 published: true
 title: "Communication - One Step Forward, Two Steps Slack?"
-author: "Chris Carter"
+authors:
+  - "Chris Carter"
 main_image: "http://bit.ly/1T7CAl0"
 tags:
   - Culture

--- a/source/blog/2015-08-07-unboxed-roundup-our-links-for-w-c-3rd-august-2015.html.markdown
+++ b/source/blog/2015-08-07-unboxed-roundup-our-links-for-w-c-3rd-august-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-08-07 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 3rd August 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-08-14-unboxed-roundup-our-links-for-w-c-10th-august-2015.html.markdown
+++ b/source/blog/2015-08-14-unboxed-roundup-our-links-for-w-c-10th-august-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-08-14 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 10th August 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-08-20-planting-the-seeds-for-successful-kpi-trees.html.markdown
+++ b/source/blog/2015-08-20-planting-the-seeds-for-successful-kpi-trees.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-08-20 11:30:00 UTC"
 published: true
 title: "Planting the seeds for successful KPI trees"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-08-21-unboxed-roundup-our-links-for-w-c-17th-august-2015.html.markdown
+++ b/source/blog/2015-08-21-unboxed-roundup-our-links-for-w-c-17th-august-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-08-21 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 17th August 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-08-28-unboxed-roundup-our-links-for-w-c-24th-august-2015.html.markdown
+++ b/source/blog/2015-08-28-unboxed-roundup-our-links-for-w-c-24th-august-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-08-28 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 24th August 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-09-04-unboxed-roundup-our-links-for-w-c-31st-august-2015.html.markdown
+++ b/source/blog/2015-09-04-unboxed-roundup-our-links-for-w-c-31st-august-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-09-04 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 31st August 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-09-09-agile-pon-de-beach-2015-agileotb.html.markdown
+++ b/source/blog/2015-09-09-agile-pon-de-beach-2015-agileotb.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-09-09 13:00:00 UTC"
 published: true
 title: "Agile pon de Beach 2015 - #AgileOTB"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 tags:
   - Agile
   - Culture

--- a/source/blog/2015-09-11-unboxed-roundup-our-links-for-w-c-7th-september-2015.html.markdown
+++ b/source/blog/2015-09-11-unboxed-roundup-our-links-for-w-c-7th-september-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-09-11 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 7th September 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-09-14-thinking-product-at-mind-the-product-2015.html.markdown
+++ b/source/blog/2015-09-14-thinking-product-at-mind-the-product-2015.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-09-14 10:35:00 UTC"
 published: true
 title: "Thinking product at Mind the Product 2015"
-author: "Martyn Evans"
+authors:
+  - "Martyn Evans"
 main_image: "http://i60.tinypic.com/x5r30n.jpg"
 tags:
   - Innovation

--- a/source/blog/2015-09-18-replacing-the-asset-pipeline-with-gulp.html.markdown
+++ b/source/blog/2015-09-18-replacing-the-asset-pipeline-with-gulp.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-09-18 16:15:00 UTC"
 published: true
 title: "Replacing the Asset pipeline with Gulp"
-author: "Anson Kelly"
+authors:
+  - "Anson Kelly"
 tags:
   - Rails
 ---

--- a/source/blog/2015-09-18-unboxed-roundup-our-links-for-w-c-14th-september-2015.html.markdown
+++ b/source/blog/2015-09-18-unboxed-roundup-our-links-for-w-c-14th-september-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-09-18 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 14th September 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-09-21-visualising-uk-government-petitions.html.markdown
+++ b/source/blog/2015-09-21-visualising-uk-government-petitions.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-09-21 08:00:00 UTC"
 published: true
 title: "Visualising UK Government Petitions"
-author: "Cale Tilford"
+authors:
+  - "Cale Tilford"
 tags:
   - Innovation
 

--- a/source/blog/2015-09-24-andrew-white-s-technical-breakfast-club-what-s-coming-in-rails-5-0.html.markdown
+++ b/source/blog/2015-09-24-andrew-white-s-technical-breakfast-club-what-s-coming-in-rails-5-0.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-09-24 09:45:00 UTC"
 published: true
 title: "Event: Andrew White’s Technical Breakfast Club - What's coming in Rails 5.0?"
-author: "Graeme McCubbin"
+authors:
+  - "Graeme McCubbin"
 main_image: "http://bit.ly/1iCddwP"
 tags:
   - Culture

--- a/source/blog/2015-09-25-unboxed-roundup-our-links-for-w-c-21st-september-2015.html.markdown
+++ b/source/blog/2015-09-25-unboxed-roundup-our-links-for-w-c-21st-september-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-09-25 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 21st September 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-10-02-summer-at-unboxed-round-two.html.markdown
+++ b/source/blog/2015-10-02-summer-at-unboxed-round-two.html.markdown
@@ -2,7 +2,8 @@
 date: "2015-10-02 10:30:00 UTC"
 published: true
 title: "Summer at Unboxed - Round Two"
-author: "Charlie Egan"
+authors:
+  - "Charlie Egan"
 tags:
   - "Culture"
 

--- a/source/blog/2015-10-02-unboxed-roundup-our-links-for-w-c-28th-september-2015.html.markdown
+++ b/source/blog/2015-10-02-unboxed-roundup-our-links-for-w-c-28th-september-2015.html.markdown
@@ -3,7 +3,8 @@ weekly_roundup: true
 date: "2015-10-02 13:30:00 UTC"
 published: true
 title: "Unboxed Roundup: Our links for w/c 28th September 2015"
-author: "Murray Steele"
+authors:
+  - "Murray Steele"
 tags:
   - Culture
 ---

--- a/source/blog/2015-10-09-unboxed-roundup-our-links-for-w-c-5th-october-2015.html.markdown
+++ b/source/blog/2015-10-09-unboxed-roundup-our-links-for-w-c-5th-october-2015.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 5th October 2015'
 date: '2015-10-09 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags:
   - Culture
 

--- a/source/blog/2015-10-12-product-management-versus-product-ownership.html.markdown
+++ b/source/blog/2015-10-12-product-management-versus-product-ownership.html.markdown
@@ -1,7 +1,8 @@
 ---
 title: 'Product Management versus Product Ownership'
 date: '2015-10-12 11:00:00 UTC'
-author: 'Martyn Evans'
+authors:
+  - 'Martyn Evans'
 tags:
 - Agile
 - Culture

--- a/source/blog/2015-10-16-unboxed-roundup-our-links-for-w-c-11th-october-2015.html.markdown
+++ b/source/blog/2015-10-16-unboxed-roundup-our-links-for-w-c-11th-october-2015.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 11th October 2015'
 date: '2015-10-16 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags:
   - Culture
 

--- a/source/blog/2015-10-23-unboxed-roundup-our-links-for-w-c-19th-october-2015.html.markdown
+++ b/source/blog/2015-10-23-unboxed-roundup-our-links-for-w-c-19th-october-2015.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 19th October 2015'
 date: '2015-10-23 09:58:04 UTC'
-author: 'Chris Carter'
+authors:
+  - 'Chris Carter'
 tags: # (Delete as appropiate)
 - Culture
 

--- a/source/blog/2015-10-30-unboxed-roundup-our-links-for-w-c-26th-october-2015.html.markdown
+++ b/source/blog/2015-10-30-unboxed-roundup-our-links-for-w-c-26th-october-2015.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 26th October 2015'
 date: '2015-10-30 14:20:09 UTC'
-author: 'Chris Carter'
+authors:
+  - 'Chris Carter'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2015-11-06-unboxed-roundup-our-links-for-w-c-2nd-november-2015.html.markdown
+++ b/source/blog/2015-11-06-unboxed-roundup-our-links-for-w-c-2nd-november-2015.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 2nd November 2015'
 date: '2015-11-06 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2015-11-13-unboxed-roundup-our-links-for-w-c-9th-november-2015.html.markdown
+++ b/source/blog/2015-11-13-unboxed-roundup-our-links-for-w-c-9th-november-2015.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 9th November 2015'
 date: '2015-11-13 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2015-11-20-unboxed-roundup-our-links-for-w-c-16th-november-2015.html.markdown
+++ b/source/blog/2015-11-20-unboxed-roundup-our-links-for-w-c-16th-november-2015.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 16th November 2015'
 date: '2015-11-20 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2015-11-26-an-e-xperience-in-colombia.md
+++ b/source/blog/2015-11-26-an-e-xperience-in-colombia.md
@@ -1,5 +1,6 @@
 ---
-author: Martyn Evans
+authors:
+  - Martyn Evans
 tags: 
   - Innovation
 main_image: "http://i963.photobucket.com/albums/ae115/Ubxd/martyn-speaking-colombia_zpscahcr9us.jpg"

--- a/source/blog/2015-11-27-unboxed-roundup-our-links-for-w-c-23rd-november-2015.html.markdown
+++ b/source/blog/2015-11-27-unboxed-roundup-our-links-for-w-c-23rd-november-2015.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 23rd November 2015'
 date: '2015-11-27 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2015-12-04-unboxed-roundup-our-links-for-w-c-30th-november-2015.html.markdown
+++ b/source/blog/2015-12-04-unboxed-roundup-our-links-for-w-c-30th-november-2015.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 30th November 2015'
 date: '2015-12-04 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2015-12-07-event-the-50k-springboard.md
+++ b/source/blog/2015-12-07-event-the-50k-springboard.md
@@ -1,5 +1,6 @@
 ---
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags: 
   - Agile
 main_image: "http://i1291.photobucket.com/albums/b548/grammccram/Screen%20Shot%202015-12-08%20at%2015.43.35_zpsbqfopsv4.png"

--- a/source/blog/2015-12-11-unboxed-roundup-our-links-for-w-c-7th-december-2015.html.markdown
+++ b/source/blog/2015-12-11-unboxed-roundup-our-links-for-w-c-7th-december-2015.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 7th December 2015'
 date: '2015-12-11 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2015-12-18-unboxed-roundup-our-links-for-w-c-14th-december-2015.html.markdown
+++ b/source/blog/2015-12-18-unboxed-roundup-our-links-for-w-c-14th-december-2015.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 14th December 2015'
 date: '2015-12-18 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-01-08-unboxed-roundup-our-links-for-w-c-4th-january-2016.html.markdown
+++ b/source/blog/2016-01-08-unboxed-roundup-our-links-for-w-c-4th-january-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 4th January 2016'
 date: '2016-01-08 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-01-11-learning-in-local-government-through-discovery.md
+++ b/source/blog/2016-01-11-learning-in-local-government-through-discovery.md
@@ -1,5 +1,6 @@
 ---
-author: Martyn Evans
+authors:
+  - Martyn Evans
 tags: 
   - Agile
   - Design

--- a/source/blog/2016-01-14-guest-post-david-santoro-carwow-cto-talks-ruby.md
+++ b/source/blog/2016-01-14-guest-post-david-santoro-carwow-cto-talks-ruby.md
@@ -1,5 +1,6 @@
 ---
-author: Carrie Bedingfield
+authors:
+  - Carrie Bedingfield
 tags: 
   - Agile
   - Rails

--- a/source/blog/2016-01-15-lift-digital.md
+++ b/source/blog/2016-01-15-lift-digital.md
@@ -1,5 +1,6 @@
 ---
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags: 
   - Innovation
 main_image: ""

--- a/source/blog/2016-01-15-unboxed-roundup-our-links-for-w-c-11th-january-2016.html.markdown
+++ b/source/blog/2016-01-15-unboxed-roundup-our-links-for-w-c-11th-january-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 11th January 2016'
 date: '2016-01-15 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-01-18-guest-post-learning-in-local-government-part-2.md
+++ b/source/blog/2016-01-18-guest-post-learning-in-local-government-part-2.md
@@ -1,5 +1,6 @@
 ---
-author: Helen Gracie
+authors:
+  - Helen Gracie
 tags: 
   - Agile
   - Culture

--- a/source/blog/2016-01-22-unboxed-roundup-our-links-for-w-c-18th-january-2016.html.markdown
+++ b/source/blog/2016-01-22-unboxed-roundup-our-links-for-w-c-18th-january-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 18th January 2016'
 date: '2016-01-22 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-01-26-snowhow-mountain-vs-startup.md
+++ b/source/blog/2016-01-26-snowhow-mountain-vs-startup.md
@@ -1,5 +1,6 @@
 ---
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags: 
   - Culture
   - Innovation

--- a/source/blog/2016-01-29-unboxed-roundup-our-links-for-w-c-25th-january-2016.html.markdown
+++ b/source/blog/2016-01-29-unboxed-roundup-our-links-for-w-c-25th-january-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 25th January 2016'
 date: '2016-01-29 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-02-02-the-unboxed-product-accelerator-adventure-goes-to-south-africa.md
+++ b/source/blog/2016-02-02-the-unboxed-product-accelerator-adventure-goes-to-south-africa.md
@@ -1,5 +1,6 @@
 ---
-author: Carrie Bedingfield
+authors:
+  - Carrie Bedingfield
 tags: 
   - Culture
   - Innovation

--- a/source/blog/2016-02-05-unboxed-roundup-our-links-for-w-c-1st-february-2016.html.markdown
+++ b/source/blog/2016-02-05-unboxed-roundup-our-links-for-w-c-1st-february-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 1st February 2016'
 date: '2016-02-05 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-02-12-unboxed-roundup-our-links-for-w-c-8th-february-2016.html.markdown
+++ b/source/blog/2016-02-12-unboxed-roundup-our-links-for-w-c-8th-february-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 8th February 2016'
 date: '2016-02-12 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-02-19-unboxed-roundup-our-links-for-w-c-15th-february-2016.html.markdown
+++ b/source/blog/2016-02-19-unboxed-roundup-our-links-for-w-c-15th-february-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 15th February 2016'
 date: '2016-02-19 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-02-26-unboxed-roundup-our-links-for-w-c-22nd-february-2016.html.markdown
+++ b/source/blog/2016-02-26-unboxed-roundup-our-links-for-w-c-22nd-february-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 22nd February 2016'
 date: '2016-02-26 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-03-04-unboxed-roundup-our-links-for-w-c-29th-february-2016.html.markdown
+++ b/source/blog/2016-03-04-unboxed-roundup-our-links-for-w-c-29th-february-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 29th February 2016'
 date: '2016-03-04 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-03-07-recruitment-test-driven-candidate-self-selection.md
+++ b/source/blog/2016-03-07-recruitment-test-driven-candidate-self-selection.md
@@ -1,5 +1,6 @@
 ---
-author: Claire Kemp
+authors:
+  - Claire Kemp
 tags: 
   - Culture
   - Innovation

--- a/source/blog/2016-03-11-unboxed-roundup-our-links-for-w-c-7th-march-2016.html.markdown
+++ b/source/blog/2016-03-11-unboxed-roundup-our-links-for-w-c-7th-march-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 7th March 2016'
 date: '2016-03-11 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-03-18-event-digitalising-local-government-services.md
+++ b/source/blog/2016-03-18-event-digitalising-local-government-services.md
@@ -1,5 +1,6 @@
 ---
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags: 
   - Agile
   - Culture

--- a/source/blog/2016-03-18-unboxed-roundup-our-links-for-w-c-14th-march-2016.html.markdown
+++ b/source/blog/2016-03-18-unboxed-roundup-our-links-for-w-c-14th-march-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 14th March 2016'
 date: '2016-03-18 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-03-24-unboxed-roundup-our-links-for-w-c-21st-march-2016.html.markdown
+++ b/source/blog/2016-03-24-unboxed-roundup-our-links-for-w-c-21st-march-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 21st March 2016'
 date: '2016-03-24 14:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-04-01-unboxed-roundup-our-links-for-w-c-28th-march-2016.html.markdown
+++ b/source/blog/2016-04-01-unboxed-roundup-our-links-for-w-c-28th-march-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 28th March 2016'
 date: '2016-04-01 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-04-08-unboxed-roundup-our-links-for-w-c-4th-april-2016.html.markdown
+++ b/source/blog/2016-04-08-unboxed-roundup-our-links-for-w-c-4th-april-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 4th April 2016'
 date: '2016-04-08 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-04-14-4-reasons-why-it-s-wise-to-bring-your-developers-along-to-business-and-design-meetings.md
+++ b/source/blog/2016-04-14-4-reasons-why-it-s-wise-to-bring-your-developers-along-to-business-and-design-meetings.md
@@ -1,5 +1,6 @@
 ---
-author: Andrew White
+authors:
+  - Andrew White
 tags: 
   - Agile
   - Design

--- a/source/blog/2016-04-15-unboxed-roundup-our-links-for-w-c-11th-april-2016.html.markdown
+++ b/source/blog/2016-04-15-unboxed-roundup-our-links-for-w-c-11th-april-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 11th April 2016'
 date: '2016-04-15 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-04-21-spanning-the-rift-beginning-your-first-agile-project-in-a-waterfall-organisation.md
+++ b/source/blog/2016-04-21-spanning-the-rift-beginning-your-first-agile-project-in-a-waterfall-organisation.md
@@ -1,5 +1,6 @@
 ---
-author: Steve Lennon
+authors:
+  - Steve Lennon
 tags: 
   - Agile
   - Innovation

--- a/source/blog/2016-04-22-unboxed-roundup-our-links-for-w-c-18th-april-2016.html.markdown
+++ b/source/blog/2016-04-22-unboxed-roundup-our-links-for-w-c-18th-april-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 18th April 2016'
 date: '2016-04-22 13:30:00 UTC'
-author: 'Chris Carter'
+authors:
+  - 'Chris Carter'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-04-27-shaking-up-early-product-development-part-1-using-journey-mapping-to-improve-your-user-journey.md
+++ b/source/blog/2016-04-27-shaking-up-early-product-development-part-1-using-journey-mapping-to-improve-your-user-journey.md
@@ -1,5 +1,6 @@
 ---
-author: Martyn Evans
+authors:
+  - Martyn Evans
 tags: 
   - Agile
   - Design

--- a/source/blog/2016-04-29-unboxed-roundup-our-links-for-w-c-25th-april-2016.html.markdown
+++ b/source/blog/2016-04-29-unboxed-roundup-our-links-for-w-c-25th-april-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 25th April 2016'
 date: '2016-04-29 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-05-04-shaking-up-early-product-development-part-2-the-minimum-viable-product.md
+++ b/source/blog/2016-05-04-shaking-up-early-product-development-part-2-the-minimum-viable-product.md
@@ -1,5 +1,6 @@
 ---
-author: Martyn Evans
+authors:
+  - Martyn Evans
 tags: 
   - Agile
   - Innovation

--- a/source/blog/2016-05-13-unboxed-roundup-our-links-for-w-c-9th-may-2016.html.markdown
+++ b/source/blog/2016-05-13-unboxed-roundup-our-links-for-w-c-9th-may-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 9th May 2016'
 date: '2016-05-13 13:30:00 UTC'
-author: 'Henry Turner'
+authors:
+  - 'Henry Turner'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-05-20-unboxed-roundup-our-links-for-w-c-16th-may-2016.html.markdown
+++ b/source/blog/2016-05-20-unboxed-roundup-our-links-for-w-c-16th-may-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 16th May 2016'
 date: '2016-05-20 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-06-03-unboxed-roundup-our-links-for-w-c-30th-may-2016.html.markdown
+++ b/source/blog/2016-06-03-unboxed-roundup-our-links-for-w-c-30th-may-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 30th May 2016'
 date: '2016-06-03 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-06-07-slowly-slowly-catch-an-employment-contract.md
+++ b/source/blog/2016-06-07-slowly-slowly-catch-an-employment-contract.md
@@ -2,7 +2,8 @@
 date: '2016-06-07 14:16 +0100'
 published: false
 title: Slowly slowly catch an employment contract
-author: Claire Kemp
+authors:
+  - Claire Kemp
 tags:
   - Agile
   - Culture

--- a/source/blog/2016-06-09-faster-than-lightning-may-s-monthly-developer-event.md
+++ b/source/blog/2016-06-09-faster-than-lightning-may-s-monthly-developer-event.md
@@ -2,7 +2,8 @@
 date: '2016-06-09 13:14 +0100'
 published: true
 title: 'Faster than Lightning: May’s monthly developer event'
-author: Neil van Beinum
+authors:
+  - Neil van Beinum
 tags:
   - Innovation
   - Rails

--- a/source/blog/2016-06-10-unboxed-roundup-our-links-for-w-c-6th-june-2016.html.markdown
+++ b/source/blog/2016-06-10-unboxed-roundup-our-links-for-w-c-6th-june-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 6th June 2016'
 date: '2016-06-10 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-06-17-unboxed-roundup-our-links-for-w-c-13th-june-2016.html.markdown
+++ b/source/blog/2016-06-17-unboxed-roundup-our-links-for-w-c-13th-june-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 13th June 2016'
 date: '2016-06-17 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-07-01-unboxed-roundup-our-links-for-w-c-27th-june-2016.html.markdown
+++ b/source/blog/2016-07-01-unboxed-roundup-our-links-for-w-c-27th-june-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 27th June 2016'
 date: '2016-07-01 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-07-08-unboxed-roundup-our-links-for-w-c-4th-july-2016.html.markdown
+++ b/source/blog/2016-07-08-unboxed-roundup-our-links-for-w-c-4th-july-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 4th July 2016'
 date: '2016-07-08 13:30:00 UTC'
-author: 'Paula Stepinska'
+authors:
+  - 'Paula Stepinska'
 tags: # (Delete as appropiate) 
 - Culture
 

--- a/source/blog/2016-07-13-unboxed-roundup-our-links-for-w-c-11th-july-2016.html.markdown
+++ b/source/blog/2016-07-13-unboxed-roundup-our-links-for-w-c-11th-july-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 11th July 2016'
 date: '2016-07-13 13:30:00 UTC'
-author: 'Paula Stepinska'
+authors:
+  - 'Paula Stepinska'
 tags: # (Delete as appropiate) 
 - Culture
 

--- a/source/blog/2016-07-19-sharedigital-conference-2016.md
+++ b/source/blog/2016-07-19-sharedigital-conference-2016.md
@@ -7,7 +7,8 @@ main_image: >-
 tags:
   - Culture
   - Innovation
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 ---
 <b>The conference:</b> Share Digital 2016<br/>
 <b>The date:</b> Wednesday 6th July<br/>

--- a/source/blog/2016-07-22-brighton-ruby-conference-2016.html.markdown
+++ b/source/blog/2016-07-22-brighton-ruby-conference-2016.html.markdown
@@ -8,7 +8,8 @@ tags:
   - Culture
   - Innovation
   - Rails
-author: Jon Pepler
+authors:
+  - Jon Pepler
 ---
 [Brighton Ruby](http://brightonruby.com/) is unsurprisingly a conference about Ruby based in Brighton, and organised by [@AndyCroll](https://twitter.com/andycroll). Being quite new to both Ruby and to Rails, a Ruby conference seemed like the perfect place to pickup a few tricks of the trade and see what's next for the language and community.
 

--- a/source/blog/2016-07-22-meetup-ux-for-life.md
+++ b/source/blog/2016-07-22-meetup-ux-for-life.md
@@ -2,7 +2,8 @@
 date: '2016-07-22 11:03 +0100'
 published: true
 title: 'Meetup: UX For Life '
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags:
   - Culture
   - Innovation

--- a/source/blog/2016-07-22-unboxed-roundup-our-links-for-w-c-18th-july-2016.html.markdown
+++ b/source/blog/2016-07-22-unboxed-roundup-our-links-for-w-c-18th-july-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 18th July 2016'
 date: '2016-07-22 13:30:00 UTC'
-author: 'Paula Stepinska'
+authors:
+  - 'Paula Stepinska'
 tags: # (Delete as appropiate) 
 - Culture
 

--- a/source/blog/2016-07-29-unboxed-roundup-our-links-for-w-c-25th-july-2016.html.markdown
+++ b/source/blog/2016-07-29-unboxed-roundup-our-links-for-w-c-25th-july-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 25th July 2016'
 date: '2016-07-29 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropiate)
 - Culture
 

--- a/source/blog/2016-08-05-unboxed-roundup-our-links-for-w-c-1st-august-2016.html.markdown
+++ b/source/blog/2016-08-05-unboxed-roundup-our-links-for-w-c-1st-august-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 1st August 2016'
 date: '2016-08-05 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropiate)
 - Culture
 

--- a/source/blog/2016-08-12-faster-than-lightning-july-s-developer-event.md
+++ b/source/blog/2016-08-12-faster-than-lightning-july-s-developer-event.md
@@ -2,7 +2,8 @@
 date: '2016-08-12 12:15 +0100'
 published: true
 title: 'Faster than Lightning: July’s Developer Event'
-author: Neil van Beinum
+authors:
+  - Neil van Beinum
 tags:
   - Culture
   - Innovation

--- a/source/blog/2016-08-12-unboxed-roundup-our-links-for-w-c-8th-august-2016.html.markdown
+++ b/source/blog/2016-08-12-unboxed-roundup-our-links-for-w-c-8th-august-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 8th August 2016'
 date: '2016-08-12 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropiate)
 - Culture
 

--- a/source/blog/2016-08-19-unboxed-roundup-our-links-for-w-c-14th-august-2016.html.markdown
+++ b/source/blog/2016-08-19-unboxed-roundup-our-links-for-w-c-14th-august-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 14th August 2016'
 date: '2016-08-19 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-08-26-unboxed-roundup-our-links-for-w-c-22nd-august-2016.html.markdown
+++ b/source/blog/2016-08-26-unboxed-roundup-our-links-for-w-c-22nd-august-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 22nd August 2016'
 date: '2016-08-26 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-09-02-unboxed-roundup-our-links-for-w-c-30th-august-2016.html.markdown
+++ b/source/blog/2016-09-02-unboxed-roundup-our-links-for-w-c-30th-august-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 30th August 2016'
 date: '2016-09-02 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-09-05-docker-re-bundling.html.markdown
+++ b/source/blog/2016-09-05-docker-re-bundling.html.markdown
@@ -1,5 +1,6 @@
 ---
-author: Charlie Egan
+authors:
+  - Charlie Egan
 tags: 
   - Rails
   - Innovation

--- a/source/blog/2016-09-09-unboxed-roundup-our-links-for-w-c-5th-september-2016.html.markdown
+++ b/source/blog/2016-09-09-unboxed-roundup-our-links-for-w-c-5th-september-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 5th September 2016'
 date: '2016-09-09 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-09-14-re-addressing-the-challenges-to-children-s-allergy-healthcare-with-guy-s-and-st-thomas.md
+++ b/source/blog/2016-09-14-re-addressing-the-challenges-to-children-s-allergy-healthcare-with-guy-s-and-st-thomas.md
@@ -4,7 +4,8 @@ published: true
 title: >-
   Re-addressing the challenges to children’s allergy healthcare with Guy’s and
   St. Thomas’
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags:
   - Agile
   - Design

--- a/source/blog/2016-09-16-unboxed-roundup-our-links-for-w-c-12th-september-2016.html.markdown
+++ b/source/blog/2016-09-16-unboxed-roundup-our-links-for-w-c-12th-september-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 12th September 2016'
 date: '2016-09-16 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-09-19-event-agile-pilot-how-to-deliver-stuck-digital-products-and-encourage-innovation-across-your-organisation.md
+++ b/source/blog/2016-09-19-event-agile-pilot-how-to-deliver-stuck-digital-products-and-encourage-innovation-across-your-organisation.md
@@ -4,7 +4,8 @@ published: true
 title: >-
   Event: Agile Pilot - How to deliver "stuck" digital products and encourage
   innovation across your organisation
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags:
   - Agile
   - Culture

--- a/source/blog/2016-09-22-andrew-white-s-technical-breakfast-club-scaling-up-rails-in-a-national-referendum.md
+++ b/source/blog/2016-09-22-andrew-white-s-technical-breakfast-club-scaling-up-rails-in-a-national-referendum.md
@@ -4,7 +4,8 @@ published: true
 title: >-
   Andrew White’s Technical Breakfast Club: Scaling up Rails in a national
   referendum
-author: Andrew White
+authors:
+  - Andrew White
 tags:
   - Rails
 main_image: >-

--- a/source/blog/2016-09-23-unboxed-roundup-our-links-for-w-c-19th-september-2016.html.markdown
+++ b/source/blog/2016-09-23-unboxed-roundup-our-links-for-w-c-19th-september-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 19th September 2016'
 date: '2016-09-23 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-09-30-faster-than-lightning-september-s-developer-event.md
+++ b/source/blog/2016-09-30-faster-than-lightning-september-s-developer-event.md
@@ -2,7 +2,8 @@
 date: '2016-09-30 16:23 +0100'
 published: true
 title: 'Faster than Lightning: September''s Developer Event'
-author: Neil van Beinum
+authors:
+  - Neil van Beinum
 tags:
   - Culture
   - Innovation

--- a/source/blog/2016-09-30-unboxed-roundup-our-links-for-w-c-26th-september-2016.html.markdown
+++ b/source/blog/2016-09-30-unboxed-roundup-our-links-for-w-c-26th-september-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 26th September 2016'
 date: '2016-09-30 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-10-07-unboxed-roundup-our-links-for-w-c-3rd-october-2016.html.markdown
+++ b/source/blog/2016-10-07-unboxed-roundup-our-links-for-w-c-3rd-october-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 3rd October 2016'
 date: '2016-10-07 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropriate)
 - Culture
 

--- a/source/blog/2016-10-11-digital-customer-programme-discovery-phase-show-tell-1-with-newham-council.md
+++ b/source/blog/2016-10-11-digital-customer-programme-discovery-phase-show-tell-1-with-newham-council.md
@@ -2,7 +2,8 @@
 date: '2016-10-11 15:00 +0100'
 published: true
 title: 'Digital Customer Programme Discovery Phase: Show & Tell #1 with Newham Council'
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags:
   - Agile
   - Culture

--- a/source/blog/2016-10-13-unboxed-roundup-our-links-for-w-c-10th-october-2016.html.markdown
+++ b/source/blog/2016-10-13-unboxed-roundup-our-links-for-w-c-10th-october-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 10th October 2016'
 date: '2016-10-13 13:30:00 UTC'
-author: 'Paula Stepinska'
+authors:
+  - 'Paula Stepinska'
 tags: # (Delete as appropiate) 
 - Culture
 

--- a/source/blog/2016-10-14-unboxed-hackathon-what-a-difference-a-day-makes.html.markdown
+++ b/source/blog/2016-10-14-unboxed-hackathon-what-a-difference-a-day-makes.html.markdown
@@ -1,7 +1,8 @@
 ---
 title: Unboxed Hackathon - what a difference a day makes
 date: '2016-10-14 09:13:05 UTC'
-author: Chris Holmes
+authors:
+  - Chris Holmes
 tags:
   - Culture
   - Innovation

--- a/source/blog/2016-10-21-unboxed-roundup-our-links-for-w-c-17th-october-2016.html.markdown
+++ b/source/blog/2016-10-21-unboxed-roundup-our-links-for-w-c-17th-october-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 17th October 2016'
 date: '2016-10-21 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropiate)
 - Culture
 

--- a/source/blog/2016-10-26-digital-customer-programme-discovery-phase-show-tell-3-with-newham-council.md
+++ b/source/blog/2016-10-26-digital-customer-programme-discovery-phase-show-tell-3-with-newham-council.md
@@ -2,7 +2,8 @@
 date: '2016-10-26 14:06 +0100'
 published: true
 title: 'Digital Customer Programme Discovery Phase: Show & Tell #3 with Newham Council'
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags:
   - Agile
   - Culture

--- a/source/blog/2016-10-28-next-london-2016-google-cloud-platform-s-user-conference.md
+++ b/source/blog/2016-10-28-next-london-2016-google-cloud-platform-s-user-conference.md
@@ -2,8 +2,8 @@
 date: '2016-10-28 10:39 +0100'
 published: true
 title: NEXT London 2016 - Google Cloud Platform's User Conference
-author: Charlie Egan
-coauthors:
+authors:
+  - Charlie Egan
   - Paula Stepinska
 tags:
   - Culture

--- a/source/blog/2016-10-28-next-london-2016-google-cloud-platform-s-user-conference.md
+++ b/source/blog/2016-10-28-next-london-2016-google-cloud-platform-s-user-conference.md
@@ -2,9 +2,9 @@
 date: '2016-10-28 10:39 +0100'
 published: true
 title: NEXT London 2016 - Google Cloud Platform's User Conference
-authors: 
+author: Charlie Egan
+coauthors:
   - Paula Stepinska
-  - Charlie Egan
 tags:
   - Culture
   - Innovation
@@ -21,7 +21,7 @@ Across the day, we attended a number of sessions from the Plenary and Breakout t
 ## GCP Next 2016 conference impressions - [Charlie](https://unboxed.co/people#charlie-egan)
 
 # Painless container management with Google Container Engine & Kubernetes
-This was the first talk in the big hall. Craig Box gave a similar overview of 
+This was the first talk in the big hall. Craig Box gave a similar overview of
 Kubernetes to his presentation at Container Camp last month. Kubernetes is
 Google's open source container scheduler based their experience building Borg,
 their internal scheduler. The problem of running persistent workloads in
@@ -75,11 +75,11 @@ was required.<br/>
 
 He also talked about a game they played called "The Will of Misfortune". Played
 Individually or collaboratively, the game involves talking through a past failure
-scenario and discussing actions they'd take. I thought this sounded like 
+scenario and discussing actions they'd take. I thought this sounded like
 something we could have a go at sometime as a developer event.<br/>
 
 There were also a good 15 mins of questions that he handled very well. Questions
-ranged from on-call compensation (which he passed on) to some hard questions 
+ranged from on-call compensation (which he passed on) to some hard questions
 about recent downtime on GCP products. His answers to these shed more light on
 the process and was a great bonus - people were clearly interested, but
 skeptical, in the SRE setup.<br/>
@@ -87,10 +87,10 @@ skeptical, in the SRE setup.<br/>
 
 ## GCP Next 2016 conference impressions - [Paula](https://unboxed.co/people#paula-stepinska)
 
-This certainly was a big selling event. But Google managed to spark the interest 
-in their different Google Cloud products, presenting how to solve real problems 
-with these products, rather than hosting a series of marketing session to _sell_ 
-these to us. I learned that GCP has a lot to offer, with its fast, quite 
+This certainly was a big selling event. But Google managed to spark the interest
+in their different Google Cloud products, presenting how to solve real problems
+with these products, rather than hosting a series of marketing session to _sell_
+these to us. I learned that GCP has a lot to offer, with its fast, quite
 affordable and insanely scalable products.<br/>
 
 From the day-long conference, there were two presentations that I really enjoyed
@@ -99,17 +99,17 @@ From the day-long conference, there were two presentations that I really enjoyed
 <br/>
 # Presentation #1: Supercharging Firebase with Google Cloud Platform
 
-When in need of comfortable and easy-to-use "backend-as-a-service", here comes 
-a Firebase as a production ready, multi-platform (web, iOS, Android), real time 
+When in need of comfortable and easy-to-use "backend-as-a-service", here comes
+a Firebase as a production ready, multi-platform (web, iOS, Android), real time
 database solution, with an instant connection to various Google's APIs - like
-a neural network based Vision API, which is able not only to recognise an image 
-of the cat, but in many cases it will tell where the picture was taken or who 
+a neural network based Vision API, which is able not only to recognise an image
+of the cat, but in many cases it will tell where the picture was taken or who
 has produced your cat's food (at least if the bag is in the picture).<br/>
 
-During Sara Robinson’s live coding session, in which she used to build a simple 
-messaging app, she showcased how Firebase combined with GCP  provides 
-the possibilities to store images, videos or other large files, and how to use 
-Firebase Analytics. There is no doubt that these are many examples of 
+During Sara Robinson’s live coding session, in which she used to build a simple
+messaging app, she showcased how Firebase combined with GCP  provides
+the possibilities to store images, videos or other large files, and how to use
+Firebase Analytics. There is no doubt that these are many examples of
 infrastructure advantages that developers now won't have to worry about anymore.<br/>
 
 ![Firebase session](http://imageshack.com/a/img921/4791/bGWQv6.jpg)
@@ -117,24 +117,24 @@ infrastructure advantages that developers now won't have to worry about anymore.
 <br/>
 # Presentation #2: Tensorflow and deep learning (without a PhD)
 
-It was promised that no PhD was required, but 
-[Martin Gorner](https://twitter.com/martin_gorner)'s talk was definitely 
-addressed to people who have vast knowledge of Machine Learning and terms, such 
-as [Softmax classifier](https://en.wikipedia.org/wiki/Softmax_function#Neural_networks), 
+It was promised that no PhD was required, but
+[Martin Gorner](https://twitter.com/martin_gorner)'s talk was definitely
+addressed to people who have vast knowledge of Machine Learning and terms, such
+as [Softmax classifier](https://en.wikipedia.org/wiki/Softmax_function#Neural_networks),
 ringing a big bell for them.<br/>
 
-It's no secret that Google has had a major focus on machine learning for a while now. 
-Within the [Google Brain](https://en.wikipedia.org/wiki/Google_Brain) project, 
-they have started to explore a deep learning/artificial neural networks trend 
-in ML and last year they open sourced [Tensorflow](https://www.tensorflow.org/), 
-a library for numerical computation, which uses data flow graphs. This has been 
+It's no secret that Google has had a major focus on machine learning for a while now.
+Within the [Google Brain](https://en.wikipedia.org/wiki/Google_Brain) project,
+they have started to explore a deep learning/artificial neural networks trend
+in ML and last year they open sourced [Tensorflow](https://www.tensorflow.org/),
+a library for numerical computation, which uses data flow graphs. This has been
 used for Google Photos and voice recognition, among the others technologies.
-During the presentation, Martin was using the MNIST database of handwritten 
-digits (commonly used for training and testing in ML) to show how TensorFlow 
-works and what can be achieved with it (training a model to predict the digits 
-by looking at images). With a whole new product family, Cloud Machine Learning 
-strives to take a machine learning mainstream, and with Vision, Speech or 
-Natural Language APIs, we're much closer to developing applications that can 
+During the presentation, Martin was using the MNIST database of handwritten
+digits (commonly used for training and testing in ML) to show how TensorFlow
+works and what can be achieved with it (training a model to predict the digits
+by looking at images). With a whole new product family, Cloud Machine Learning
+strives to take a machine learning mainstream, and with Vision, Speech or
+Natural Language APIs, we're much closer to developing applications that can
 “understand” the world around them.
 
 ![Martin Gorner and TensorFlow in action](http://imageshack.com/a/img923/8261/3ZiPHl.jpg)

--- a/source/blog/2016-10-28-next-london-2016-google-cloud-platform-s-user-conference.md
+++ b/source/blog/2016-10-28-next-london-2016-google-cloud-platform-s-user-conference.md
@@ -2,7 +2,9 @@
 date: '2016-10-28 10:39 +0100'
 published: true
 title: NEXT London 2016 - Google Cloud Platform's User Conference
-author: Charlie Egan
+authors: 
+  - Paula Stepinska
+  - Charlie Egan
 tags:
   - Culture
   - Innovation

--- a/source/blog/2016-10-28-unboxed-roundup-our-links-for-w-c-24th-october-2016.html.markdown
+++ b/source/blog/2016-10-28-unboxed-roundup-our-links-for-w-c-24th-october-2016.html.markdown
@@ -2,7 +2,8 @@
 weekly_roundup: true
 title: 'Unboxed Roundup: Our links for w/c 24th October 2016'
 date: '2016-10-28 13:30:00 UTC'
-author: 'Murray Steele'
+authors:
+  - 'Murray Steele'
 tags: # (Delete as appropiate)
 - Culture
 

--- a/source/blog/feed.rss.builder
+++ b/source/blog/feed.rss.builder
@@ -14,6 +14,8 @@ xml.rss :version => "2.0", "xmlns:atom" => "http://www.w3.org/2005/Atom" do
     xml.tag! 'atom:link', 'href' => URI.join(site_url, current_page.path), 'rel' => 'self', 'type' => 'application/rss+xml'
 
     articles.each do |article|
+      current_authors = article_info(data.people, article.data).current_authors
+
       xml.item do
         xml.title article.title
         xml.description article.body
@@ -21,9 +23,7 @@ xml.rss :version => "2.0", "xmlns:atom" => "http://www.w3.org/2005/Atom" do
         xml.link URI.join(site_url, article.url)
         xml.guid atom_id(article), "isPermaLink" => "false"
 
-        article_author = article.data.author || article.data.authors.first
-        author = data.people.detect { |person| person.name.downcase == article_author.downcase }
-        if author
+        current_authors.each do |author|
           xml.author "#{author.email}@unboxed.co (#{author.name})"
         end
       end

--- a/source/blog/feed.rss.builder
+++ b/source/blog/feed.rss.builder
@@ -21,7 +21,8 @@ xml.rss :version => "2.0", "xmlns:atom" => "http://www.w3.org/2005/Atom" do
         xml.link URI.join(site_url, article.url)
         xml.guid atom_id(article), "isPermaLink" => "false"
 
-        author = data.people.detect { |person| person.name.downcase == article.data.author.downcase }
+        article_author = article.data.author || article.data.authors.first
+        author = data.people.detect { |person| person.name.downcase == article_author.downcase }
         if author
           xml.author "#{author.email}@unboxed.co (#{author.name})"
         end

--- a/source/blog/feed.xml.builder
+++ b/source/blog/feed.xml.builder
@@ -20,7 +20,8 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xml:lang" => "en-GB" do
       xml.updated File.mtime(article.source_file).iso8601
       xml.tags article.tags
       xml.author do
-        author = data.people.detect { |person| person.name.downcase == article.data.author.downcase }
+        article_author = article.data.author || article.data.authors.first
+        author = data.people.detect { |person| person.name.downcase == article_author.downcase }
         if author
           xml.name author.name
           xml.email "#{author.email}@unboxed.co"

--- a/source/blog/feed.xml.builder
+++ b/source/blog/feed.xml.builder
@@ -19,17 +19,21 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xml:lang" => "en-GB" do
       xml.published article.date.to_time.iso8601
       xml.updated File.mtime(article.source_file).iso8601
       xml.tags article.tags
-      xml.author do
-        article_author = article.data.author || article.data.authors.first
-        author = data.people.detect { |person| person.name.downcase == article_author.downcase }
-        if author
-          xml.name author.name
-          xml.email "#{author.email}@unboxed.co"
-          xml.uri "https://unboxedconsulting.com/people/#{author.short_name}"
-        else
-          xml.name article.data.author
+
+      current_authors = article_info(data.people, article.data).current_authors
+
+      if current_authors.any?
+        current_authors.each do |author|
+          xml.author do
+            xml.name author.name
+            xml.email "#{author.email}@unboxed.co"
+            xml.uri "https://unboxedconsulting.com/people/#{author.short_name}"
+          end
         end
+      else
+        xml.name article.data.author
       end
+
       xml.content article.body, "type" => "html"
     end
   end

--- a/source/blog_author_grid.erb
+++ b/source/blog_author_grid.erb
@@ -9,4 +9,4 @@
   </div>
 </div>
 
-<%= partial 'blog_grid', locals: { articles: blog(:blog).articles.select { |article| article.data.author == author_name } } %>
+<%= partial 'blog_grid', locals: { articles: blog(:blog).articles.select { |article| article.data.authors.include? author_name } } %>

--- a/source/index.erb
+++ b/source/index.erb
@@ -246,7 +246,7 @@ blog_title: "What we have been blogging about"
 
           <div>
             <div class="homepage-blog-tile__author">
-              <%= article.data.author %>
+              <%= article_info(data.people, article.data).author_names %>
             </div>
 
             <div class="homepage-blog-tile__date">

--- a/source/layouts/blog_article.erb
+++ b/source/layouts/blog_article.erb
@@ -1,12 +1,3 @@
-<% if current_page.data.author %>
-  <% author = data.people.detect { |person| person.name.downcase == current_page.data.author.downcase } %>
-  <% authors = author.nil? ? false : [author] %>
-<% elsif current_page.data.authors %>
-  <% authors = current_page.data.authors.map { |name| data.people.detect { |author| author.name.downcase == name.downcase } }.compact %>
-<% else %>
-  <% authors = false %>
-<% end %>
-
 <% content_for(:title) { "Blog - #{current_page.data.title}" } %>
 <% content_for(:meta_description) { truncate(strip_tags(current_article.body), length: 150) } %>
 <% content_for(:meta_keywords) { "unboxed consulting, news, technical, web, development, marketing, graphic design, Unboxed, Ruby on Rails, Blog, #{current_page.data.tags.join(', ')}" } %>
@@ -22,6 +13,9 @@
 <% end %>
 
 <% wrap_layout :application do %>
+  <% article_info = article_info(data.people, current_page.data) %>
+  <% authors = article_info.authors %>
+
   <section class="blog-article">
     <div class="blog-article__container">
 
@@ -31,15 +25,18 @@
         </h1>
 
         <div class="blog-header__subtitle">
-          <% if authors %>
-            <% authors.each_with_index do |a, i| %>
-              <a class="blog-header__author--linked" href="/people#<%= a.short_name %>" rel="author"><%= a.name %></a><!--
-              --><%= ", " if i != authors.size - 1 %>
+          <% authors.each_with_index do |author, index| %>
+            <% if author.short_name %>
+              <a class="blog-header__author--linked" href="/people#<%= author.short_name %>" rel="author">
+                <%= author.name %>
+              </a>
+            <% else %>
+              <div class="blog-header__author">
+                <%= author.name %>
+              </div>
             <% end %>
-          <% else %>
-            <div class="blog-header__author">
-              <%= current_page.data.author %>
-            </div>
+
+            <%= ", " if index != authors.size - 1 %>
           <% end %>
 
           <div class="blog-header__published-date">
@@ -67,28 +64,26 @@
 
   <div class="blog-footer">
     <div class="blog-footer__container">
-      <% if authors %>
-        <% authors.each_with_index do |a, i| %>
-          <section class="blog-author">
-            <% if sitemap.find_resource_by_path "/assets/images/people/#{a.short_name}.png" %>
-              <img class="blog-author__image" src="/assets/images/people/<%= a.short_name %>.png" alt="<%= a.name %>"/>
-            <% end %>
-            <aside class="blog-author__right-section">
-              <a class="blog-author__name" href="/people#<%= a.short_name %>">
-                <%= a.name %>
-              </a>
-              <div class="blog-author__bio">
-                <%= simple_format a.bio %>
-              </div>
+      <% article_info.current_authors.each_with_index do |a, i| %>
+        <section class="blog-author">
+          <% if sitemap.find_resource_by_path "/assets/images/people/#{a.short_name}.png" %>
+            <img class="blog-author__image" src="/assets/images/people/<%= a.short_name %>.png" alt="<%= a.name %>"/>
+          <% end %>
+          <aside class="blog-author__right-section">
+            <a class="blog-author__name" href="/people#<%= a.short_name %>">
+              <%= a.name %>
+            </a>
+            <div class="blog-author__bio">
+              <%= simple_format a.bio %>
+            </div>
 
-              <% if blog(:blog).articles.select { |article| article.data.author == a.name }.size >= 2 %>
-                <a class="blog-author__read-more" href="/blog/author/<%= a.short_name %>">
-                  Read more posts by <%= a.name %>
-                </a>
-              <% end %>
-            </aside>
-          </section>
-        <% end %>
+            <% if blog(:blog).articles.select { |article| article.data.author == a.name }.size >= 2 %>
+              <a class="blog-author__read-more" href="/blog/author/<%= a.short_name %>">
+                Read more posts by <%= a.name %>
+              </a>
+            <% end %>
+          </aside>
+        </section>
       <% end %>
 
       <%= partial 'layouts/disqus', locals: { article_slug: current_page.slug } %>

--- a/source/layouts/blog_article.erb
+++ b/source/layouts/blog_article.erb
@@ -1,4 +1,10 @@
-<% author = data.people.detect { |person| person.name.downcase == current_page.data.author.downcase } %>
+<% if current_page.data.author %>
+  <% author = data.people.detect { |person| person.name.downcase == current_page.data.author.downcase } %>
+  <% authors = [author] %>
+<% elsif current_page.data.authors %>
+  <% authors = current_page.data.authors.map { |name| data.people.detect { |author| author.name.downcase == name.downcase } }.compact %>
+<% end %>
+
 <% content_for(:title) { "Blog - #{current_page.data.title}" } %>
 <% content_for(:meta_description) { truncate(strip_tags(current_article.body), length: 150) } %>
 <% content_for(:meta_keywords) { "unboxed consulting, news, technical, web, development, marketing, graphic design, Unboxed, Ruby on Rails, Blog, #{current_page.data.tags.join(', ')}" } %>
@@ -23,10 +29,11 @@
         </h1>
 
         <div class="blog-header__subtitle">
-          <% if author %>
-            <a class="blog-header__author--linked" href="/people#<%= author.short_name %>" rel="author">
-              <%= author.name %>
-            </a>
+          <% if authors %>
+            <% authors.each_with_index do |a, i| %>
+              <a class="blog-header__author--linked" href="/people#<%= a.short_name %>" rel="author"><%= a.name %></a><!--
+              --><%= ", " if i != authors.size - 1 %>
+            <% end %>
           <% else %>
             <div class="blog-header__author">
               <%= current_page.data.author %>
@@ -58,26 +65,28 @@
 
   <div class="blog-footer">
     <div class="blog-footer__container">
-      <% if author %>
-        <section class="blog-author">
-          <% if sitemap.find_resource_by_path "/assets/images/people/#{author.short_name}.png" %>
-            <img class="blog-author__image" src="/assets/images/people/<%= author.short_name %>.png" alt="<%= author.name %>"/>
-          <% end %>
-          <aside class="blog-author__right-section">
-            <a class="blog-author__name" href="/people#<%= author.short_name %>">
-              <%= author.name %>
-            </a>
-            <div class="blog-author__bio">
-              <%= simple_format author.bio %>
-            </div>
-
-            <% if blog(:blog).articles.select { |article| article.data.author == author.name }.size >= 2 %>
-              <a class="blog-author__read-more" href="/blog/author/<%= author.short_name %>">
-                Read more posts by <%= author.name %>
-              </a>
+      <% if authors %>
+        <% authors.each_with_index do |a, i| %>
+          <section class="blog-author">
+            <% if sitemap.find_resource_by_path "/assets/images/people/#{a.short_name}.png" %>
+              <img class="blog-author__image" src="/assets/images/people/<%= a.short_name %>.png" alt="<%= a.name %>"/>
             <% end %>
-          </aside>
-        </section>
+            <aside class="blog-author__right-section">
+              <a class="blog-author__name" href="/people#<%= a.short_name %>">
+                <%= a.name %>
+              </a>
+              <div class="blog-author__bio">
+                <%= simple_format a.bio %>
+              </div>
+
+              <% if blog(:blog).articles.select { |article| article.data.author == a.name }.size >= 2 %>
+                <a class="blog-author__read-more" href="/blog/author/<%= a.short_name %>">
+                  Read more posts by <%= a.name %>
+                </a>
+              <% end %>
+            </aside>
+          </section>
+        <% end %>
       <% end %>
 
       <%= partial 'layouts/disqus', locals: { article_slug: current_page.slug } %>

--- a/source/layouts/blog_article.erb
+++ b/source/layouts/blog_article.erb
@@ -26,17 +26,11 @@
 
         <div class="blog-header__subtitle">
           <% authors.each_with_index do |author, index| %>
-            <% if author.short_name %>
-              <a class="blog-header__author--linked" href="/people#<%= author.short_name %>" rel="author">
-                <%= author.name %>
-              </a>
+            <% if author.short_name.present? %>
+              <a class="blog-header__author--linked" href="/people#<%= author.short_name %>" rel="author"><%= author.name %></a><%= ", " if index != authors.size - 1 %>
             <% else %>
-              <div class="blog-header__author">
-                <%= author.name %>
-              </div>
+              <div class="blog-header__author"><%= author.name %></div><%= ", " if index != authors.size - 1 %>
             <% end %>
-
-            <%= ", " if index != authors.size - 1 %>
           <% end %>
 
           <div class="blog-header__published-date">

--- a/source/layouts/blog_article.erb
+++ b/source/layouts/blog_article.erb
@@ -1,8 +1,10 @@
 <% if current_page.data.author %>
   <% author = data.people.detect { |person| person.name.downcase == current_page.data.author.downcase } %>
-  <% authors = [author] %>
+  <% authors = author.nil? ? false : [author] %>
 <% elsif current_page.data.authors %>
   <% authors = current_page.data.authors.map { |name| data.people.detect { |author| author.name.downcase == name.downcase } }.compact %>
+<% else %>
+  <% authors = false %>
 <% end %>
 
 <% content_for(:title) { "Blog - #{current_page.data.title}" } %>

--- a/source/layouts/blog_article.erb
+++ b/source/layouts/blog_article.erb
@@ -77,7 +77,7 @@
               <%= simple_format a.bio %>
             </div>
 
-            <% if blog(:blog).articles.select { |article| article.data.author == a.name }.size >= 2 %>
+            <% if blog(:blog).articles.select { |article| article.data.authors.include? a.name }.size >= 2 %>
               <a class="blog-author__read-more" href="/blog/author/<%= a.short_name %>">
                 Read more posts by <%= a.name %>
               </a>

--- a/source/layouts/blog_article.erb
+++ b/source/layouts/blog_article.erb
@@ -103,7 +103,7 @@
 
             <div>
               <div class="blog-related-tile__author">
-                <%= article.data.author %>
+                <%= article_info(data.people, article.data).author_names %>
               </div>
 
               <div class="blog-related-tile__date">

--- a/spec/article_info_spec.rb
+++ b/spec/article_info_spec.rb
@@ -42,4 +42,17 @@ RSpec.describe ArticleInfo do
       expect(article.current_authors).to eq [johnny]
     end
   end
+
+  describe "#author_names" do
+    it "returns the author names in a comma separated string" do
+      johnny = PersonData.new(name: "Johnny")
+      jane = PersonData.new(name: "Jane")
+      page = PageData.new(author: "Johnny", coauthors: ["Jane", "Jimmy"])
+      people = [jane, johnny]
+
+      article = described_class.new(people, page)
+
+      expect(article.author_names).to eq "Johnny, Jane, Jimmy"
+    end
+  end
 end

--- a/spec/article_info_spec.rb
+++ b/spec/article_info_spec.rb
@@ -1,0 +1,45 @@
+require './lib/article_info.rb'
+
+class PageData
+  attr_reader :author, :coauthors
+
+  def initialize(author: nil, coauthors: nil)
+    @author = author
+    @coauthors = coauthors
+  end
+end
+
+class PersonData
+  attr_reader :name
+
+  def initialize(name: nil)
+    @name = name
+  end
+end
+
+RSpec.describe ArticleInfo do
+  describe "#authors" do
+    it "returns a collection with the author and coauthors" do
+      johnny = PersonData.new(name: "Johnny")
+      jane = PersonData.new(name: "Jane")
+      page = PageData.new(author: "Johnny", coauthors: ["Jane", "Jimmy"])
+      people = [jane, johnny]
+
+      article = described_class.new(people, page)
+
+      expect(article.authors.map(&:name)).to eq ["Johnny", "Jane", "Jimmy"]
+    end
+  end
+
+  describe "#current_authors" do
+    it "returns authors excluding any who are not currently in people" do
+      johnny = PersonData.new(name: "Johnny")
+      page = PageData.new(author: "Johnny", coauthors: ["Jane", "Jimmy"])
+      people = [johnny]
+
+      article = described_class.new(people, page)
+
+      expect(article.current_authors).to eq [johnny]
+    end
+  end
+end

--- a/spec/article_info_spec.rb
+++ b/spec/article_info_spec.rb
@@ -1,11 +1,10 @@
 require './lib/article_info.rb'
 
 class PageData
-  attr_reader :author, :coauthors
+  attr_reader :authors
 
-  def initialize(author: nil, coauthors: nil)
-    @author = author
-    @coauthors = coauthors
+  def initialize(authors: nil)
+    @authors = authors
   end
 end
 
@@ -22,7 +21,7 @@ RSpec.describe ArticleInfo do
     it "returns a collection with the author and coauthors" do
       johnny = PersonData.new(name: "Johnny")
       jane = PersonData.new(name: "Jane")
-      page = PageData.new(author: "Johnny", coauthors: ["Jane", "Jimmy"])
+      page = PageData.new(authors: ["Johnny", "Jane", "Jimmy"])
       people = [jane, johnny]
 
       article = described_class.new(people, page)
@@ -34,7 +33,7 @@ RSpec.describe ArticleInfo do
   describe "#current_authors" do
     it "returns authors excluding any who are not currently in people" do
       johnny = PersonData.new(name: "Johnny")
-      page = PageData.new(author: "Johnny", coauthors: ["Jane", "Jimmy"])
+      page = PageData.new(authors: ["Johnny", "Jane", "Jimmy"])
       people = [johnny]
 
       article = described_class.new(people, page)
@@ -47,7 +46,7 @@ RSpec.describe ArticleInfo do
     it "returns the author names in a comma separated string" do
       johnny = PersonData.new(name: "Johnny")
       jane = PersonData.new(name: "Jane")
-      page = PageData.new(author: "Johnny", coauthors: ["Jane", "Jimmy"])
+      page = PageData.new(authors: ["Johnny", "Jane", "Jimmy"])
       people = [jane, johnny]
 
       article = described_class.new(people, page)

--- a/spec/article_sorter_spec.rb
+++ b/spec/article_sorter_spec.rb
@@ -1,30 +1,36 @@
 require './lib/related_blog_articles.rb'
 
 class BlogData
-  attr_reader :author, :tags
+  attr_reader :authors, :tags
 
-  def initialize(author: nil, tags: nil)
-    @author = author
+  def initialize(authors: nil, tags: nil)
+    @authors = authors
     @tags = tags
   end
 
-  def ==(other)
-    self.author == other.author && self.tags == other.tags
-  end
+  # def ==(other)
+  #   self.author == other.author && self.tags == other.tags
+  # end
 end
 
 describe RelatedBlogArticles do
   describe '.weight' do
     describe 'authors' do
       it 'has the maximum author weighting when authors are the same' do
-        current_article = BlogData.new(author: 'A', tags: [])
-        other_article = BlogData.new(author: 'A', tags: [])
+        current_article = BlogData.new(authors: ['A'], tags: [])
+        other_article = BlogData.new(authors: ['A'], tags: [])
+        expect(described_class.new(current_article, other_article).weight).to eq 1.0
+      end
+
+      it 'has the maximum author weighting when multiple authors are the same' do
+        current_article = BlogData.new(authors: ['A', 'B'], tags: [])
+        other_article = BlogData.new(authors: ['A', 'B'], tags: [])
         expect(described_class.new(current_article, other_article).weight).to eq 1.0
       end
 
       it 'has no author weighting when authors are different' do
-        current_article = BlogData.new(author: 'A', tags: [])
-        other_article = BlogData.new(author: 'B', tags: [])
+        current_article = BlogData.new(authors: ['A'], tags: [])
+        other_article = BlogData.new(authors: ['B'], tags: [])
         expect(described_class.new(current_article, other_article).weight).to eq 0.0
       end
 
@@ -33,30 +39,36 @@ describe RelatedBlogArticles do
         other_article = BlogData.new(tags: [])
         expect(described_class.new(current_article, other_article).weight).to eq 0.0
       end
+
+      it 'has a 50% author weighting when authors are similar by a half' do
+        current_article = BlogData.new(authors: ['A', 'C'])
+        other_article = BlogData.new(authors: ['B', 'A'])
+        expect(described_class.new(current_article, other_article).weight).to eq 0.5
+      end
     end
 
     describe 'tags' do
       it 'has the maximum tag weighting when tags are exactly the same' do
-        current_article = BlogData.new(author: 'A', tags: ['A'])
-        other_article = BlogData.new(author: 'B', tags: ['A'])
+        current_article = BlogData.new(authors: ['A'], tags: ['A'])
+        other_article = BlogData.new(authors: ['B'], tags: ['A'])
         expect(described_class.new(current_article, other_article).weight).to eq 1.0
       end
 
       it 'has a 50% tag weighting when tags are similar by a half' do
-        current_article = BlogData.new(author: 'A', tags: ['A', 'B'])
-        other_article = BlogData.new(author: 'B', tags: ['A', 'C'])
+        current_article = BlogData.new(authors: ['A'], tags: ['A', 'B'])
+        other_article = BlogData.new(authors: ['B'], tags: ['A', 'C'])
         expect(described_class.new(current_article, other_article).weight).to eq 0.5
       end
 
       it 'has no tag weighting when tags are different' do
-        current_article = BlogData.new(author: 'A', tags: ['A'])
-        other_article = BlogData.new(author: 'B', tags: ['B'])
+        current_article = BlogData.new(authors: ['A'], tags: ['A'])
+        other_article = BlogData.new(authors: ['B'], tags: ['B'])
         expect(described_class.new(current_article, other_article).weight).to eq 0.0
       end
 
       it 'has no tag weighting when tags are not present' do
-        current_article = BlogData.new(author: 'A')
-        other_article = BlogData.new(author: 'B', tags: [])
+        current_article = BlogData.new(authors: ['A'])
+        other_article = BlogData.new(authors: ['B'], tags: [])
         expect(described_class.new(current_article, other_article).weight).to eq 0.0
       end
     end

--- a/spec/former_employee_spec.rb
+++ b/spec/former_employee_spec.rb
@@ -1,0 +1,41 @@
+require './lib/former_employee'
+
+RSpec.describe FormerEmployee do
+  let(:former_employee) { described_class.new("Chris Holmes") }
+
+  it "returns the employees name" do
+    expect(former_employee.name).to eq "Chris Holmes"
+  end
+
+  context "implementing methods available on people data" do
+    describe "#short_name" do
+      it "returns an empty string" do
+        expect(former_employee.short_name).to eq ""
+      end
+    end
+
+    describe "#role" do
+      it "returns an empty string" do
+        expect(former_employee.role).to eq ""
+      end
+    end
+
+    describe "#email" do
+      it "returns an empty string" do
+        expect(former_employee.email).to eq ""
+      end
+    end
+
+    describe "#bio" do
+      it "returns an empty string" do
+        expect(former_employee.bio).to eq ""
+      end
+    end
+
+    describe "#social_networks" do
+      it "returns an empty array" do
+        expect(former_employee.social_networks).to eq []
+      end
+    end
+  end
+end

--- a/spec/non_employee_spec.rb
+++ b/spec/non_employee_spec.rb
@@ -1,6 +1,6 @@
-require './lib/former_employee'
+require './lib/non_employee'
 
-RSpec.describe FormerEmployee do
+RSpec.describe NonEmployee do
   let(:former_employee) { described_class.new("Chris Holmes") }
 
   it "returns the employees name" do


### PR DESCRIPTION
Sometimes posts have more than one author, it'd be nice to represent
this on post pages.

This reads from `author` or `authors` from the front matter to build a
list of authors. The list of authors is used to draw the page (list of
names at the top, list of 'profiles' at the bottom).
