### PR TITLE
Update newham discovery post to use authors format

### DIFF
--- a/source/blog/2016-11-02-digital-customer-programme-discovery-phase-show-tell-5-with-newham-council.md
+++ b/source/blog/2016-11-02-digital-customer-programme-discovery-phase-show-tell-5-with-newham-council.md
@@ -2,7 +2,8 @@
 date: '2016-11-02 18:24 +0000'
 published: true
 title: 'Digital Customer Programme Discovery Phase: Show & Tell #5 with Newham Council'
-author: Graeme McCubbin
+authors:
+  - Graeme McCubbin
 tags:
   - Agile
   - Innovation


### PR DESCRIPTION
We recently changed the format of article data from author to authors
to support multiple authors. A recent article created in Prose was using
the old author key which caused the build to fail.