### PR TITLE
More links for 2017

### DIFF
--- a/source/blog/2017-01-06-unboxed-roundup-our-links-for-fortnight-commencing-26th-december-2016.html.markdown
+++ b/source/blog/2017-01-06-unboxed-roundup-our-links-for-fortnight-commencing-26th-december-2016.html.markdown
@@ -19,6 +19,14 @@ If you've studied computer graphics at all you should get a kick out of these
 photos of real world objects arranged to mimic classic CGI render scenes. The
 effort that has gone in to replicating these is quite something.
 
+## A list of programming languages that are actively developed on GitHub - [Charlie E](/people#charlie-egan)
+
+https://github.com/showcases/programming-languages
+
+The title really should be "A list of programming languages with a GitHub repo."
+since a number of these are mirrors - still, it's nice to see this extension to
+the GitHub Explore page.
+
 ## Data storage formats - [Murray S](/people#murray-steele)
 
 __Spoilers for Rogue One: A Star Wars Story within, be warned__

--- a/source/blog/2017-01-06-unboxed-roundup-our-links-for-fortnight-commencing-26th-december-2016.html.markdown
+++ b/source/blog/2017-01-06-unboxed-roundup-our-links-for-fortnight-commencing-26th-december-2016.html.markdown
@@ -39,4 +39,11 @@ notable exception: data storage formats.  The Star Wars films display a baffling
 array of data storage formats, and the technology seems to go backwards from the
 prequels.
 
-## Track of the Week - [](/people#)
+## Track of the Week - [Grant S](/people#grant-speelman)
+
+My choice for track of the week is "Meghan Trainor, Me too". The youtube video is a Cape Town dance group dancing to the song.
+My Son currently loves this and I watch it at least 30 times a day because of that.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/J10YcOMd6kU" frameborder="0" allowfullscreen></iframe>
+
+[Rudi Smit - Me Too](https://www.youtube.com/watch?v=J10YcOMd6kU)

--- a/source/blog/2017-01-06-unboxed-roundup-our-links-for-fortnight-commencing-26th-december-2016.html.markdown
+++ b/source/blog/2017-01-06-unboxed-roundup-our-links-for-fortnight-commencing-26th-december-2016.html.markdown
@@ -11,6 +11,15 @@ tags: # (Delete as appropriate)
 
 We missed last week because it was the Christmas and New Year break.
 
+## Faster than Lightning meetup - [Graeme M] (/people/#graeme-mccubbin)
+
+https://www.eventbrite.co.uk/e/meetup-faster-than-lightning-code-talks-tickets-30922768834
+
+We're bringing our monthly internal 'Faster than Lightning' event to the
+community, with the first taking place in February. A series of short, informal
+talks based around code snippets. We've got limited places, so register now if
+you're interested in coming along.
+
 ## Real life CGI Rendering - [Murray S](/people#murray-steele)
 
 http://skrekkogle.com/still-file/


### PR DESCRIPTION
Added the blog post and first links to production by mistake, can't be bothered to revert.  The publication date of the post is in the future anyway so it won't go live yet.