### PR TITLE
Fix the spec for articles_by_author

### DIFF
--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -34,9 +34,12 @@ RSpec.describe Helpers do
     let(:article_1) { double("BlogArtcile", data: double('data', authors: ['Brian de la Smith'])) }
     let(:article_2) { double("BlogArtcile", data: double('data', authors: ['Brian DE LA Smith', 'Simone Grant'])) }
     let(:article_3) { double("BlogArtcile", data: double('data', authors: ['Aisling Noble'])) }
-    let(:blog) { double('blog', articles: [article_1, article_2, article_3]) }
-    before do
-      allow(self).to receive(:blog).with(:blog).and_return(blog)
+    let(:blog_object) { double('blog', articles: [article_1, article_2, article_3]) }
+
+    # this method is implemented by middleman-blog and we can't stub it directly
+    # because the helpers module doesn't implement it on it's own
+    def blog(which_blog)
+      blog_object
     end
 
     it 'includes articles written by the supplied author if they are the sole author' do


### PR DESCRIPTION
Lulled into a false sense of security about why the build was failing (
I thought it was because rspec wasn't properly configured which I fixed
in a separate PR - #298) I merged this (#305) without properly checking the spec results.

The problem was that we were trying to stub `blog` but also creating a
let variable called `blog`.  Changing the name of the let variable exposed
a different problem: the Helpers module doesn't implement `blog`
directly (it comes from middleman-blog) and so we need to provide a default
implementation instead of using a stub because we've configured rspec to
not let you stub methods that haven't been implemented.