### PR TITLE
Fix safari bug with blog tiles

### DIFF
--- a/source/_blog_grid.erb
+++ b/source/_blog_grid.erb
@@ -13,29 +13,31 @@
 
 <%= javascript_include_tag "packery.min" %>
 <script>
-  var packeryContainer = document.querySelector('[data-packery-target]');
-  var packeryOptions = {
-    transitionDuration: 0,
-    percentPosition: true,
-    itemSelector: '.blog-tile',
-    columnWidth: '.blog-tile__grid-sizer'
-  };
+  window.onload = function() {
+    var packeryContainer = document.querySelector('[data-packery-target]');
+    var packeryOptions = {
+      transitionDuration: 0,
+      percentPosition: true,
+      itemSelector: '.blog-tile',
+      columnWidth: '.blog-tile__grid-sizer'
+    };
 
-  if (typeof window.matchMedia != "undefined" || typeof window.msMatchMedia != "undefined") {
-    var mq = matchMedia('(min-width: 660px)');
-    var packery;
+    if (typeof window.matchMedia != "undefined" || typeof window.msMatchMedia != "undefined") {
+      var mq = matchMedia('(min-width: 660px)');
+      var packery;
 
-    if (mq.matches) {
-      packery = new Packery(packeryContainer, packeryOptions);
-    }
-
-    mq.addListener(function(mql) {
-      if (mql.matches) {
+      if (mq.matches) {
         packery = new Packery(packeryContainer, packeryOptions);
-      } else {
-        packery.destroy();
       }
-    });
+
+      mq.addListener(function(mql) {
+        if (mql.matches) {
+          packery = new Packery(packeryContainer, packeryOptions);
+        } else {
+          packery.destroy();
+        }
+      });
+    }
   }
 </script>
 

--- a/source/assets/stylesheets/styles/_blog_tile.scss
+++ b/source/assets/stylesheets/styles/_blog_tile.scss
@@ -1,4 +1,3 @@
 .blog-tile__grid-sizer {
-  width: 33.333;
   width: calc(100%/3);
 }


### PR DESCRIPTION
There is a bug in Safari when a user first loads the blog page that
results in large gaps inbetween tiles. Subsequent loads of the page is
fine though. Investigation has led me to believe that the blog tiles
are arranged by a javascript plugin `Packery` in blog_grid.erb.
I suspect that the script is loading before the page is fully ready
resulting in some sort of calculation error in the grid arrangement.
By adding a window.onload, we can be sure that the script only fires
when the DOM is ready.