### PR TITLE
Update numbers in Petitions project story

### DIFF
--- a/source/product-stories/petitions.erb
+++ b/source/product-stories/petitions.erb
@@ -13,7 +13,7 @@ introduction:
     - "10 weeks to live launch in July 2015"
     - "Relaunched platform to open new dialogue between public and Parliament"
     - "System powered by open source Rails application"
-    - "Up to 40,000 signatures submitted and processed per hour"
+    - "Up to 100,000 signatures submitted and processed per hour"
   image: "/product-stories/petitions/donald-trump-petition.jpg"
   image_description: "Petition on blocking Donald Trump from UK entry"
 
@@ -21,18 +21,18 @@ highlight_1:
   title: "Petitions in numbers"
   project: "petitions"
   statistics:
-  - number: "31,696,203"
+  - number: "31,473,502"
     text: "Signatures collected to date (August 2017)"
-  - number: "27"
+  - number: "44"
     text: "Petitions exceeding 100,000 signatures and debated in the House of Commons"
 
 highlight_2:
   title: "Petitions in numbers since launch"
   project: "petitions"
   statistics:
-  - number: "42,101,742"
+  - number: "70,966,650"
     text: "Unique site visitors"
-  - number: "246,930,801"
+  - number: "418,426,929"
     text: "Pages viewed"
 
 petition_process:
@@ -69,7 +69,7 @@ tech_quote:
 
 result:
   title: "A platform for direct public engagement with Parliament"
-  content: "The result: A platform which, for the first time, allows the public to electronically petition the Parliament Committee directly with political topics that wouldn’t otherwise have been raised or debated. Since the launch, 9,443,708 signatures have been collected across 3,215 petitions. 120 of these petitions have been given a response, and 22 debated in the House of Commons."
+  content: "The result: A platform which, for the first time, allows the public to electronically petition the Parliament Committee directly with political topics that wouldn’t otherwise have been raised or debated. Since the launch, 31,473,502 signatures have been collected across 10,950 petitions. 485 of these petitions have been given a response, and 56 debated in the House of Commons."
   image: "/product-stories/petitions/sugary-drinks-tax-petition.jpg"
   image_description: "Petition on tax on sugary drinks to improve children's health"
 


### PR DESCRIPTION
The number of signatures collected has gone down because I've excluded validated signatures on petitions that were never published - it doesn't seem right to include those in the count even though they are validated signatures.