### PR TITLE
Fix bug on large blog images in microsoft browsers

### DIFF
--- a/source/assets/stylesheets/styles/_blog_large_tile.scss
+++ b/source/assets/stylesheets/styles/_blog_large_tile.scss
@@ -130,6 +130,8 @@
   display: block;
   height: 130px;
   object-fit: cover;
+  //allows object-fit to work on IE and Edge browsers. Requires object-fit-fix/ofi.min.js to be loaded
+  font-family: "object-fit: cover";
   width: 100%;
 
   @include breakpoint($tablet-breakpoint) {


### PR DESCRIPTION
Microsoft browsers do not support object-fit styling. We use the fix
in the included object-fit-fixes javascript file to solve this.
When objectFitImages() is called at the end of the page load, the
images are resized and cropped to fit.