### PR TITLE
Remove hover on people tiles

### DIFF
--- a/source/assets/stylesheets/styles/_person_tile.scss
+++ b/source/assets/stylesheets/styles/_person_tile.scss
@@ -26,10 +26,6 @@
   padding: 14px;
   width: 100%;
 
-  &:hover {
-    background-color: mix($white, $light-gray);
-  }
-
   @include breakpoint($tablet-breakpoint) {
     height: 386px;
   }


### PR DESCRIPTION
Removed the colour change when hovering over someone's tile on the
people page, as the hover gave the illusion that the tiles are links
that can be clicked.