### PR TITLE
Fix for full width news article extended across screen

### DIFF
--- a/source/assets/stylesheets/styles/_news_article.scss
+++ b/source/assets/stylesheets/styles/_news_article.scss
@@ -1,12 +1,4 @@
 .news-article {
-  @extend .container--grid;
-
-  @include breakpoint ($desktop-breakpoint) {
-    padding-right: 6px;
-  }
-}
-
-.news-article--container {
   background-color: $white;
   box-sizing: border-box;
   margin-top: 6px;

--- a/source/layouts/news_article.erb
+++ b/source/layouts/news_article.erb
@@ -3,8 +3,8 @@
 
 <% wrap_layout :application do %>
 
-  <section class="news-article">
-    <div class="news-article--container" data-header-waypoint>
+  <section class="container">
+    <div class="news-article" data-header-waypoint>
       <header class="news-header">
         <h1 class="news-header__page-title">
           <a class="news-header__breadcrumb" href="/news">News</a> / <span class="news-header__article-title"><%= current_page.data.title %></span>


### PR DESCRIPTION
The news article layout was oddly referencing the .container--grid class even though it's not based on a grid.

Fixed this by including a nomral .container around the news article.

Also checked and there are no other lingering referencis to .container--grid that remain unsolved.