### PR TITLE
Update how component locals are used in partial

### DIFF
--- a/source/jobs.erb
+++ b/source/jobs.erb
@@ -90,7 +90,7 @@ published: true
     </div>
   </section>
 
-  <%= partial 'shared/full_image', locals: { section: current_page.data.unboxed_meeting_image } %>
+  <%= partial 'shared/full_image', locals: current_page.data.unboxed_meeting_image %>
 
   <section class="roles">
     <% if current_page.data.roles.content.nil? %>

--- a/source/jobs/designer.erb
+++ b/source/jobs/designer.erb
@@ -126,21 +126,21 @@ related:
     </div>
   </section>
 
-  <%= partial 'shared/full_image', locals: { section: current_page.data.design_image_1 } %>
+  <%= partial 'shared/full_image', locals: current_page.data.design_image_1 %>
 
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.description } %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.description %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.other_requirements } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.other_requirements %>
 
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.benefits } %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.benefits %>
 
-  <%= partial 'shared/full_image', locals: { section: current_page.data.design_image_2 } %>
+  <%= partial 'shared/full_image', locals: current_page.data.design_image_2 %>
 
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.other_benefits } %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.other_benefits %>
 
   <%= partial 'jobs/process', locals: { section: current_page.data.process } %>
 
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.design_quote } %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.design_quote %>
 
   <%= partial 'jobs/contact_us' %>
 

--- a/source/jobs/developer.erb
+++ b/source/jobs/developer.erb
@@ -121,17 +121,17 @@ related:
     </div>
   </section>
 
-  <%= partial 'shared/full_image', locals: { section: current_page.data.developers_image } %>
+  <%= partial 'shared/full_image', locals: current_page.data.developers_image %>
 
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.description } %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.description %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.other_requirements } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.other_requirements %>
 
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.benefits } %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.benefits %>
 
   <%= partial 'jobs/process', locals: { section: current_page.data.process } %>
 
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.developer_quote } %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.developer_quote %>
 
   <%= partial 'jobs/contact_us' %>
 

--- a/source/product-stories/bookmetrix.erb
+++ b/source/product-stories/bookmetrix.erb
@@ -146,7 +146,7 @@ related:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/bookmetrix.erb
+++ b/source/product-stories/bookmetrix.erb
@@ -149,24 +149,24 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.introduction } %>
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_1 } %>
-  <%= partial 'shared/two_text_tiles', locals: { section: current_page.data.section_2 } %>
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.section_3 } %>
-  <%= partial 'shared/two_text_tiles', locals: { section: current_page.data.section_4 } %>
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.quote_1 } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.introduction %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_1 %>
+  <%= partial 'shared/two_text_tiles', locals: current_page.data.section_2 %>
+  <%= partial 'shared/text_tile', locals: current_page.data.section_3 %>
+  <%= partial 'shared/two_text_tiles', locals: current_page.data.section_4 %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.quote_1 %>
 
   <%= image_tag current_page.data.image_section_1.image, alt: current_page.data.image_section_1.image_description, class: "full-image", srcset: retina_srcset(current_page.data.image_section_1.image) %>
 
-  <%= partial 'shared/two_text_tiles', locals: { section: current_page.data.section_5 } %>
-  <%= partial 'shared/text_tile_reversed', locals: { section: current_page.data.section_6 } %>
-  <%= partial 'shared/two_text_tiles', locals: { section: current_page.data.section_7 } %>
+  <%= partial 'shared/two_text_tiles', locals: current_page.data.section_5 %>
+  <%= partial 'shared/text_tile_reversed', locals: current_page.data.section_6 %>
+  <%= partial 'shared/two_text_tiles', locals: current_page.data.section_7 %>
 
   <%= image_tag current_page.data.image_section_2.image, alt: current_page.data.image_section_2.image_description, class: "full-image", srcset: retina_srcset(current_page.data.image_section_2.image) %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_2 } %>
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_3 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_2 %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_3 %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/bucks-cc-beta.erb
+++ b/source/product-stories/bucks-cc-beta.erb
@@ -144,31 +144,31 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_1 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.beta_step } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.beta_step %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_1 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.design_and_dev } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.design_and_dev %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_2 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.contact_centre } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.contact_centre %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_2 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.sys_integrations } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.sys_integrations %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_3 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_3 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.launch } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.launch %>
 
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.quote_3 } %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.quote_3 %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/bucks-cc-beta.erb
+++ b/source/product-stories/bucks-cc-beta.erb
@@ -141,7 +141,7 @@ related:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/bucks-cc.erb
+++ b/source/product-stories/bucks-cc.erb
@@ -151,7 +151,7 @@ related:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/bucks-cc.erb
+++ b/source/product-stories/bucks-cc.erb
@@ -154,35 +154,35 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_1 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.digital_service_standard } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.digital_service_standard %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.digital_services_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.digital_services_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.understanding_customer } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.understanding_customer %>
 
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.impact_quote } %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.impact_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.talking_with_customers } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.talking_with_customers %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.development_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.development_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.agile_local_council } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.agile_local_council %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.agile_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.agile_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.mvp_prototyping } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.mvp_prototyping %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_2 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.beta_phase } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.beta_phase %>
 
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.alpha_quote } %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.alpha_quote %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/channel-5.erb
+++ b/source/product-stories/channel-5.erb
@@ -111,7 +111,7 @@ related:
       link: "/product-stories/plymouth-university"
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/channel-5.erb
+++ b/source/product-stories/channel-5.erb
@@ -114,23 +114,23 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_1 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.redeveloped } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.redeveloped %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.critical_work_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.critical_work_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.visitor_experience } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.visitor_experience %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_2 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.content_management } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.content_management %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.timely_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.timely_quote %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/contiki-holidays.erb
+++ b/source/product-stories/contiki-holidays.erb
@@ -135,7 +135,7 @@ related:
       link: "/product-stories/plymouth-university"
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/contiki-holidays.erb
+++ b/source/product-stories/contiki-holidays.erb
@@ -138,27 +138,27 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.partnership } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.partnership %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_1 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.project_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.project_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.agile } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.agile %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_2 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.collaboration } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.collaboration %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.release_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.release_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.objectives } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.objectives %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.team_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.team_quote %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/naturejobs.erb
+++ b/source/product-stories/naturejobs.erb
@@ -111,9 +111,9 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.collaboration } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.collaboration %>
 
   <section class="highlight--naturejobs">
     <h2 class="highlight__title">
@@ -121,17 +121,17 @@ related:
     </h2>
   </section>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.technology } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.technology %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.collaboration_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.collaboration_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.user_journey } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.user_journey %>
 
-  <%= partial 'shared/full_video', locals: { section: current_page.data.head_of_product_video } %>
+  <%= partial 'shared/full_video', locals: current_page.data.head_of_product_video %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.metrics } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.metrics %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.mentality_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.mentality_quote %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/naturejobs.erb
+++ b/source/product-stories/naturejobs.erb
@@ -108,7 +108,7 @@ related:
       link: "/product-stories/plymouth-university"
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/newham-council.erb
+++ b/source/product-stories/newham-council.erb
@@ -135,7 +135,7 @@ related:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container newham-council" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/newham-council.erb
+++ b/source/product-stories/newham-council.erb
@@ -138,47 +138,47 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container newham-council" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.introduction %>
 
-  <%= partial 'shared/full_image', locals: { section: current_page.data.the_vision} %>
+  <%= partial 'shared/full_image', locals: current_page.data.the_vision %>
 
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.the_vision } %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.the_vision %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.why_product_required } %>
+  <%= partial 'shared/highlight', locals: current_page.data.why_product_required %>
 
-  <%= partial 'shared/two_text_tiles', locals: { section: current_page.data.end_to_end_service_focus } %>
+  <%= partial 'shared/two_text_tiles', locals: current_page.data.end_to_end_service_focus %>
 
-  <%= partial 'shared/text_tile_quote', locals: { section: current_page.data.opportunity_quote } %>
+  <%= partial 'shared/text_tile_quote', locals: current_page.data.opportunity_quote %>
 
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.heart_of_service } %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.heart_of_service %>
 
-  <%= partial 'shared/full_image', locals: { section: current_page.data.heart_of_service } %>
+  <%= partial 'shared/full_image', locals: current_page.data.heart_of_service %>
 
-  <%= partial 'shared/text_tile_quote', locals: { section: current_page.data.resident_thinking_quote } %>
+  <%= partial 'shared/text_tile_quote', locals: current_page.data.resident_thinking_quote %>
 
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.understanding_service_needs } %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.understanding_service_needs %>
 
-  <%= partial 'shared/full_image', locals: { section: current_page.data.understanding_service_needs } %>
+  <%= partial 'shared/full_image', locals: current_page.data.understanding_service_needs %>
 
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.eligibility_quote } %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.eligibility_quote %>
 
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.validate_ideas } %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.validate_ideas %>
 
-  <%= partial 'shared/full_image', locals: { section: current_page.data.validate_ideas } %>
+  <%= partial 'shared/full_image', locals: current_page.data.validate_ideas %>
 
-  <%= partial 'shared/text_tile_quote', locals: { section: current_page.data.testing_ideas_quote } %>
+  <%= partial 'shared/text_tile_quote', locals: current_page.data.testing_ideas_quote %>
 
-  <%= partial 'shared/full_width_text_and_list_tile', locals: { section: current_page.data.progression_prototypes } %>
+  <%= partial 'shared/full_width_text_and_list_tile', locals: current_page.data.progression_prototypes %>
 
-  <%= partial 'shared/full_image', locals: { section: current_page.data.progression_prototypes } %>
+  <%= partial 'shared/full_image', locals: current_page.data.progression_prototypes %>
 
-  <%= partial 'shared/full_width_text_tile', locals: { section: current_page.data.conclusion } %>
+  <%= partial 'shared/full_width_text_tile', locals: current_page.data.conclusion %>
 
-  <%= partial 'shared/full_image', locals: { section: current_page.data.conclusion } %>
+  <%= partial 'shared/full_image', locals: current_page.data.conclusion %>
 
-  <%= partial 'shared/text_tile_quote', locals: { section: current_page.data.project_quote } %>
+  <%= partial 'shared/text_tile_quote', locals: current_page.data.project_quote %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/pearson.erb
+++ b/source/product-stories/pearson.erb
@@ -150,9 +150,9 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
   <section class="highlight--pearson">
     <h2 class="highlight__title">
@@ -173,15 +173,15 @@ related:
     </div>
   </section>
 
-   <%= partial 'shared/text_tile', locals: { section: current_page.data.digital_revenue } %>
+   <%= partial 'shared/text_tile', locals: current_page.data.digital_revenue %>
 
-   <%= partial 'shared/quote', locals: { section: current_page.data.quote_1 } %>
+   <%= partial 'shared/quote', locals: current_page.data.quote_1 %>
 
-   <%= partial 'shared/text_tile', locals: { section: current_page.data.waterfall } %>
+   <%= partial 'shared/text_tile', locals: current_page.data.waterfall %>
 
-   <%= partial 'shared/quote', locals: { section: current_page.data.quote_2 } %>
+   <%= partial 'shared/quote', locals: current_page.data.quote_2 %>
 
-   <%= partial 'shared/text_tile', locals: { section: current_page.data.planning_stages } %>
+   <%= partial 'shared/text_tile', locals: current_page.data.planning_stages %>
 
    <section class="highlight--pearson">
     <h2 class="highlight__title">
@@ -202,17 +202,17 @@ related:
     </div>
   </section>
 
-   <%= partial 'shared/text_tile', locals: { section: current_page.data.new_products } %>
+   <%= partial 'shared/text_tile', locals: current_page.data.new_products %>
 
-   <%= partial 'shared/quote_caricature', locals: { section: current_page.data.quote_3 } %>
+   <%= partial 'shared/quote_caricature', locals: current_page.data.quote_3 %>
 
-   <%= partial 'shared/text_tile', locals: { section: current_page.data.deploying } %>
+   <%= partial 'shared/text_tile', locals: current_page.data.deploying %>
 
-   <%= partial 'shared/quote', locals: { section: current_page.data.quote_4 } %>
+   <%= partial 'shared/quote', locals: current_page.data.quote_4 %>
 
-   <%= partial 'shared/text_tile', locals: { section: current_page.data.launching } %>
+   <%= partial 'shared/text_tile', locals: current_page.data.launching %>
 
-   <%= partial 'shared/quote', locals: { section: current_page.data.quote_5 } %>
+   <%= partial 'shared/quote', locals: current_page.data.quote_5 %>
 
    <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/pearson.erb
+++ b/source/product-stories/pearson.erb
@@ -147,7 +147,7 @@ related:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/petition-map.erb
+++ b/source/product-stories/petition-map.erb
@@ -91,9 +91,9 @@ links:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
   <section class="highlight--petition-map">
     <h2 class="highlight__title">
@@ -108,7 +108,7 @@ links:
     </div>
   </section>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.about } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.about %>
 
   <blockquote class="quote">
     <aside class="quote__right-section">
@@ -122,13 +122,13 @@ links:
     <img class="quote__source-image" src="<%= current_page.data.quote_1.image %>" alt="<%= current_page.data.quote_1.source %>"/>
   </blockquote>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.open_source } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.open_source %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_2 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.public_following } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.public_following %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_3 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_3 %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/petition-map.erb
+++ b/source/product-stories/petition-map.erb
@@ -88,7 +88,7 @@ links:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/petitions.erb
+++ b/source/product-stories/petitions.erb
@@ -134,31 +134,31 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_1 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.petition_process } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.petition_process %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.launch_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.launch_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.new_requirements } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.new_requirements %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.mvp_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.mvp_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.tech_spec } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.tech_spec %>
 
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.tech_quote } %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.tech_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.result } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.result %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.mp_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.mp_quote %>
 
   <%= partial 'shared/project_team' %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_2 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_2 %>
 
   <%= partial 'shared/link_tiles' %>
 

--- a/source/product-stories/petitions.erb
+++ b/source/product-stories/petitions.erb
@@ -131,7 +131,7 @@ related:
     link: "/news/new-government-petitions-website-launched-developed-in-partnership-with-unboxed-consulting/"
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/plymouth-university-gets-agile.erb
+++ b/source/product-stories/plymouth-university-gets-agile.erb
@@ -108,7 +108,7 @@ related:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/plymouth-university-gets-agile.erb
+++ b/source/product-stories/plymouth-university-gets-agile.erb
@@ -111,9 +111,9 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
   <section class="highlight--plymouth-university-gets-agile">
     <h2 class="highlight__title">
@@ -121,17 +121,17 @@ related:
     </h2>
   </section>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.process_structure } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.process_structure %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.agile_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.agile_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.transparency } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.transparency %>
 
-  <%= partial 'shared/full_image', locals: { section: current_page.data.mood_board } %>
+  <%= partial 'shared/full_image', locals: current_page.data.mood_board %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.pride } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.pride %>
 
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.textbook_to_real_world_quote } %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.textbook_to_real_world_quote %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/plymouth-university.erb
+++ b/source/product-stories/plymouth-university.erb
@@ -133,29 +133,29 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
-  <%= partial 'shared/full_video', locals: { section: current_page.data.plymouth_cio_video } %>
+  <%= partial 'shared/full_video', locals: current_page.data.plymouth_cio_video %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_1 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.emerging_demands } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.emerging_demands %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_1 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.design_testing } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.design_testing %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_2 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.agile } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.agile %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_2 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.platform } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.platform %>
 
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.quote_3 } %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.quote_3 %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/plymouth-university.erb
+++ b/source/product-stories/plymouth-university.erb
@@ -130,7 +130,7 @@ related:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/reed-learning.erb
+++ b/source/product-stories/reed-learning.erb
@@ -125,7 +125,7 @@ related:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/reed-learning.erb
+++ b/source/product-stories/reed-learning.erb
@@ -128,31 +128,31 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_1 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.digital_learning } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.digital_learning %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_1 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.agile_pioneers } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.agile_pioneers %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_2 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.piloting } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.piloting %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_3 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_3 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.key_features } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.key_features %>
 
-  <%= partial 'shared/text_tile_reversed', locals: { section: current_page.data.new_product } %>
+  <%= partial 'shared/text_tile_reversed', locals: current_page.data.new_product %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_4 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_4 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.scaling_transformation } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.scaling_transformation %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/sh24.erb
+++ b/source/product-stories/sh24.erb
@@ -152,7 +152,7 @@ related:
       link: "/product-stories/channel-5"
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/product-stories/sh24.erb
+++ b/source/product-stories/sh24.erb
@@ -155,31 +155,31 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_1 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.online_process } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.online_process %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.first_met_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.first_met_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.learning } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.learning %>
 
-  <%= partial 'shared/full_video', locals: { section: current_page.data.blood_instruction_video } %>
+  <%= partial 'shared/full_video', locals: current_page.data.blood_instruction_video %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.service } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.service %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.timely_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.timely_quote %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.stakeholder_trust } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.stakeholder_trust %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_2 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.launch } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.launch %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.team_quote } %>
+  <%= partial 'shared/quote', locals: current_page.data.team_quote %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/v-and-a-museum.erb
+++ b/source/product-stories/v-and-a-museum.erb
@@ -125,27 +125,27 @@ related:
 <%= partial 'shared/page_header' %>
 
 <div class="container" data-header-waypoint>
-  <%= partial 'shared/full_image', locals: { section: current_page.data.header } %>
+  <%= partial 'shared/full_image', locals: current_page.data.header %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.introduction %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_1 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.infrastructure } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.infrastructure %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_1 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_1 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.aws } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.aws %>
 
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.quote_2 } %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.quote_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.server_load } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.server_load %>
 
-  <%= partial 'shared/highlight', locals: { section: current_page.data.highlight_2 } %>
+  <%= partial 'shared/highlight', locals: current_page.data.highlight_2 %>
 
-  <%= partial 'shared/text_tile', locals: { section: current_page.data.digital_platform } %>
+  <%= partial 'shared/text_tile', locals: current_page.data.digital_platform %>
 
-  <%= partial 'shared/quote', locals: { section: current_page.data.quote_3 } %>
+  <%= partial 'shared/quote', locals: current_page.data.quote_3 %>
 
   <%= partial 'shared/project_team' %>
 

--- a/source/product-stories/v-and-a-museum.erb
+++ b/source/product-stories/v-and-a-museum.erb
@@ -122,7 +122,7 @@ related:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= partial 'shared/full_image', locals: current_page.data.header %>

--- a/source/services/build-your-digital-product.erb
+++ b/source/services/build-your-digital-product.erb
@@ -54,7 +54,7 @@ product_stories:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= image_tag current_page.data.header.image, alt: current_page.data.header.image_description, class: "full-image", srcset: retina_srcset(current_page.data.header.image) %>

--- a/source/services/grow-and-improve.erb
+++ b/source/services/grow-and-improve.erb
@@ -54,7 +54,7 @@ product_stories:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= image_tag current_page.data.header.image, alt: current_page.data.header.image_description, class: "full-image", srcset: retina_srcset(current_page.data.header.image) %>

--- a/source/services/kickstart-digital-innovation.erb
+++ b/source/services/kickstart-digital-innovation.erb
@@ -54,7 +54,7 @@ product_stories:
 
 ---
 
-<%= partial 'shared/page_header' %>
+<%= partial 'shared/page_header', locals: current_page.data.header %>
 
 <div class="container" data-header-waypoint>
   <%= image_tag current_page.data.header.image, alt: current_page.data.header.image_description, class: "full-image", srcset: retina_srcset(current_page.data.header.image) %>

--- a/source/shared/_full_image.erb
+++ b/source/shared/_full_image.erb
@@ -1,9 +1,9 @@
 <figure>
-<%= image_tag section.image, alt: section.image_description, class: "full-image", srcset: retina_srcset(section.image) %>
+  <%= image_tag locals[:image], alt: locals[:image_description], class: "full-image", srcset: retina_srcset(locals[:image]) %>
 
-<% if section.caption %>
-  <figcaption class="full-image-caption">
-    <%= section.caption %>
-  </figcaption>
-<% end %>
+  <% if locals[:caption] %>
+    <figcaption class="full-image-caption">
+      <%= locals[:caption] %>
+    </figcaption>
+  <% end %>
 </figure>

--- a/source/shared/_full_video.erb
+++ b/source/shared/_full_video.erb
@@ -1,5 +1,5 @@
-<a href="https://www.youtube.com/watch?v=<%= section.youtube_id %>" target="_blank" data-video>
-  <%= partial 'shared/full_image', locals: { section: section } %>
+<a href="https://www.youtube.com/watch?v=<%= locals[:youtube_id] %>" target="_blank" data-video>
+  <%= partial 'shared/full_image', locals: locals %>
 </a>
 
 <script>
@@ -18,7 +18,7 @@
   }
 
   if (supports.video || supports.flash) {
-    var embed = '<div class="full-video"><iframe src="https://www.youtube.com/embed/<%= section.youtube_id %>?rel=0" frameborder="0" allowfullscreen></iframe></div>';
+    var embed = '<div class="full-video"><iframe src="https://www.youtube.com/embed/<%= locals[:youtube_id] %>?rel=0" frameborder="0" allowfullscreen></iframe></div>';
     document.querySelector("[data-video] img").outerHTML = embed;
   }
 </script>

--- a/source/shared/_full_width_text_and_list_tile.erb
+++ b/source/shared/_full_width_text_and_list_tile.erb
@@ -1,17 +1,17 @@
 <section class="component">
   <div class="text-tile--full-width">
-    <% if section.title %>
+    <% if locals[:title] %>
       <h2 class="text-tile__title--narrow">
-        <%= section.title %>
+        <%= locals[:title] %>
       </h2>
     <% end %>
 
     <p class="text-tile__paragraph">
-      <%= section.content %>
+      <%= locals[:content] %>
     </p>
 
     <ul class="text-tile__list">
-      <% section.list.each do |item| %>
+      <% locals[:list].each do |item| %>
         <li class="text-tile__list-item">
           <%= item %>
         </li>

--- a/source/shared/_full_width_text_tile.erb
+++ b/source/shared/_full_width_text_tile.erb
@@ -1,20 +1,20 @@
 <section class="component">
   <div class="text-tile--full-width">
-    <% if section.title %>
+    <% if locals[:title] %>
       <h2 class="text-tile__title--narrow">
-        <%= section.title %>
+        <%= locals[:title] %>
       </h2>
     <% end %>
 
-   <% if section.intro %>
+   <% if locals[:intro] %>
       <p class="text-tile__paragraph" >
-        <%= section.intro %>
+        <%= locals[:intro] %>
       </p>
     <% end %>
 
-    <% if section.content.is_a?(Array) %>
+    <% if locals[:content].is_a?(Array) %>
       <ul class="text-tile__list">
-        <% section.content.each do |item| %>
+        <% locals[:content].each do |item| %>
           <li class="text-tile__list-item">
             <%= item %>
           </li>
@@ -22,7 +22,7 @@
       </ul>
     <% else %>
       <p class="text-tile__paragraph">
-        <%= section.content %>
+        <%= locals[:content] %>
       </p>
     <% end %>
   </div>

--- a/source/shared/_highlight.erb
+++ b/source/shared/_highlight.erb
@@ -1,23 +1,23 @@
-<section class="highlight--<%= section.project %>">
-  <% if section.title %>
-    <h2 class="highlight__title"><%= section.title %></h2>
+<section class="highlight--<%= locals[:project] %>">
+  <% if locals[:title] %>
+    <h2 class="highlight__title"><%= locals[:title] %></h2>
   <% end %>
 
-  <% if section.statistics %>
-    <div class="highlight__tile--<%= section.statistics.size.even? ? 'two' : 'one' %>">
-      <% section.statistics.each do |statistic| %>
+  <% if locals[:statistics] %>
+    <div class="highlight__tile--<%= locals[:statistics].size.even? ? 'two' : 'one' %>">
+      <% locals[:statistics].each do |statistic| %>
         <p class="highlight__large-text">
-          <% if statistic.icon %>
-            <i class="fa <%= statistic.icon %>"></i>
+          <% if statistic[:icon] %>
+            <i class="fa <%= statistic[:icon] %>"></i>
           <% end %>
-          <%= statistic.number %>
+          <%= statistic[:number] %>
         </p>
-        <p class="highlight__small-text"><%= statistic.text %></p>
+        <p class="highlight__small-text"><%= statistic[:text] %></p>
       <% end %>
     </div>
-  <% elsif section.list %>
+  <% elsif locals[:list] %>
     <ul class="text-tile__list">
-      <% section.list.each do |item| %>
+      <% locals[:list].each do |item| %>
       <li class="text-tile__list-item">
         <%= item %>
       </li>

--- a/source/shared/_page_header.erb
+++ b/source/shared/_page_header.erb
@@ -1,7 +1,7 @@
 <header class="page-header">
   <div class="page-header__container">
     <h1 class="page-header__introduction">
-      <%= current_page.data.header.introduction %>
+      <%= locals[:introduction] %>
     </h1>
   </div>
 </header>

--- a/source/shared/_quote.erb
+++ b/source/shared/_quote.erb
@@ -1,8 +1,8 @@
 <blockquote class="quote">
   <p class="quote__text">
-    <%= section.quote %>
+    <%= locals[:quote] %>
   </p>
   <p class="quote__source">
-    <%= section.source %>
+    <%= locals[:source] %>
   </p>
 </blockquote>

--- a/source/shared/_quote_caricature.erb
+++ b/source/shared/_quote_caricature.erb
@@ -1,18 +1,18 @@
 <blockquote class="quote">
   <aside class="quote__right-section">
     <p class="quote__text--centered">
-      <%= section.quote %>
+      <%= locals[:quote] %>
     </p>
     <p class="quote__source">
-      <%= section.source %>
+      <%= locals[:source] %>
     </p>
   </aside>
 
-  <% if section.image %>
-    <% if section.image_proportion && is_jpg?(section.image) %>
-      <%= image_tag section.image, alt: section.source, class: "quote__source-image #{section.image_proportion}", srcset: retina_srcset(section.image) %>
+  <% if locals[:image] %>
+    <% if locals[:image_proportion] && is_jpg?(locals[:image]) %>
+      <%= image_tag locals[:image], alt: locals[:source], class: "quote__source-image #{locals[:image_proportion]}", srcset: retina_srcset(locals[:image]) %>
     <% else %>
-      <%= image_tag section.image, alt: section.source, class: "quote__source-image caricature" %>
+      <%= image_tag locals[:image], alt: locals[:source], class: "quote__source-image caricature" %>
     <% end %>
   <% end %>
 </blockquote>

--- a/source/shared/_text_tile.erb
+++ b/source/shared/_text_tile.erb
@@ -1,14 +1,14 @@
 <section class="component">
   <div class="component__tile text-tile">
-    <% if section.title %>
+    <% if locals[:title] %>
       <h2 class="text-tile__title">
-        <%= section.title %>
+        <%= locals[:title] %>
       </h2>
     <% end %>
 
-    <% if section.content.is_a?(Array) %>
+    <% if locals[:content].is_a?(Array) %>
       <ul class="text-tile__list">
-        <% section.content.each do |item| %>
+        <% locals[:content].each do |item| %>
           <li class="text-tile__list-item">
             <%= item %>
           </li>
@@ -16,12 +16,12 @@
       </ul>
     <% else %>
       <p class="text-tile__paragraph">
-        <%= section.content %>
+        <%= locals[:content] %>
       </p>
     <% end %>
   </div>
 
   <div class="component__tile image-tile">
-    <%= image_tag section.image, alt: section.image_description, class: "image-tile__image", srcset: retina_srcset(section.image) %>
+    <%= image_tag locals[:image], alt: locals[:image_description], class: "image-tile__image", srcset: retina_srcset(locals[:image]) %>
   </div>
 </section>

--- a/source/shared/_text_tile_quote.erb
+++ b/source/shared/_text_tile_quote.erb
@@ -1,14 +1,14 @@
 <section class="text-tile-quote">
   <blockquote class="component__tile text-tile-quote__quote">
     <p class="text-tile-quote__text">
-      <%= section.quote %>
+      <%= locals[:quote] %>
     </p>
     <p class="text-tile-quote__source">
-      <%= section.source %>
+      <%= locals[:source] %>
     </p>
   </blockquote>
 
   <div class="text-tile-quote__image">
-    <%= image_tag section.image, alt: section.image_description, class: "image-tile__image", srcset: retina_srcset(section.image) %>
+    <%= image_tag locals[:image], alt: locals[:image_description], class: "image-tile__image", srcset: retina_srcset(locals[:image]) %>
   </div>
 </section>

--- a/source/shared/_text_tile_reversed.erb
+++ b/source/shared/_text_tile_reversed.erb
@@ -1,17 +1,17 @@
 <section class="component">
   <div class="component__tile image-tile">
-    <%= image_tag section.image, alt: section.image_description, class: "image-tile__image", srcset: retina_srcset(section.image) %>
+    <%= image_tag locals[:image], alt: locals[:image_description], class: "image-tile__image", srcset: retina_srcset(locals[:image]) %>
   </div>
   <div class="component__tile text-tile">
-    <% if section.title %>
+    <% if locals[:title] %>
       <h2 class="text-tile__title">
-        <%= section.title %>
+        <%= locals[:title] %>
       </h2>
     <% end %>
 
-    <% if section.content.is_a?(Array) %>
+    <% if locals[:content].is_a?(Array) %>
       <ul class="text-tile__list">
-        <% section.content.each do |item| %>
+        <% locals[:content].each do |item| %>
           <li class="text-tile__list-item">
             <%= item %>
           </li>
@@ -19,7 +19,7 @@
       </ul>
     <% else %>
       <p class="text-tile__paragraph">
-        <%= section.content %>
+        <%= locals[:content] %>
       </p>
     <% end %>
   </div>

--- a/source/shared/_two_text_tiles.erb
+++ b/source/shared/_two_text_tiles.erb
@@ -1,17 +1,17 @@
 <section class="component">
   <div class="component__tile--title">
-    <% if section.title %>
+    <% if locals[:title] %>
       <h2 class="text-tile__title--narrow">
-        <%= section.title %>
+        <%= locals[:title] %>
       </h2>
     <% end %>
   </div>
 
   <div class="component__tile text-tile--double-tile">
-    <% if section.content_1 %>
-      <% if section.content_1.is_a?(Array) %>
+    <% if locals[:content_1] %>
+      <% if locals[:content_1].is_a?(Array) %>
         <ul class="text-tile__list">
-          <% section.content_1.each do |item| %>
+          <% locals[:content_1].each do |item| %>
             <li class="text-tile__list-item">
               <%= item %>
             </li>
@@ -19,17 +19,17 @@
         </ul>
       <% else %>
         <p class="text-tile__paragraph">
-          <%= section.content_1 %>
+          <%= locals[:content_1] %>
         </p>
       <% end %>
     <% end %>
   </div>
 
   <div class="component__tile text-tile--double-tile">
-    <% if section.content_2 %>
-      <% if section.content_2.is_a?(Array) %>
+    <% if locals[:content_2] %>
+      <% if locals[:content_2].is_a?(Array) %>
         <ul class="text-tile__list">
-          <% section.content_2.each do |item| %>
+          <% locals[:content_2].each do |item| %>
             <li class="text-tile__list-item">
               <%= item %>
             </li>
@@ -37,7 +37,7 @@
         </ul>
       <% else %>
         <p class="text-tile__paragraph">
-          <%= section.content_2 %>
+          <%= locals[:content_2] %>
         </p>
       <% end %>
     <% end %>

--- a/source/style-guide.erb
+++ b/source/style-guide.erb
@@ -11,11 +11,9 @@ title: "Style guide"
     </div>
     <div class="style-guide__container-body">
       <%= partial 'shared/text_tile', locals: {
-        section: OpenStruct.new({
           title: "Lorem ipsum dolor sit amet",
-          content: "Consectetur adipisicing elit. Consequuntur sed aliquam vero repellendus impedit qui. Quia labore, quibusdam soluta, corrupti dolor deleniti voluptatum corporis quidem vero, beatae eius voluptatem quod!",
-          image: "https://placehold.it/480x463"
-        })
+        content: "Consectetur adipisicing elit. Consequuntur sed aliquam vero repellendus impedit qui. Quia labore, quibusdam soluta, corrupti dolor deleniti voluptatum corporis quidem vero, beatae eius voluptatem quod!",
+        image: "https://placehold.it/480x463"
       } %>
     </div>
   </div>
@@ -26,10 +24,8 @@ title: "Style guide"
     </div>
     <div class="style-guide__container-body">
       <%= partial 'shared/full_image', locals: {
-        section: OpenStruct.new({
-          image: "https://placehold.it/960x480",
-          image_description: "Placehold.it"
-        })
+        image: "https://placehold.it/960x480",
+        image_description: "Placehold.it"
       } %>
     </div>
   </div>
@@ -40,16 +36,14 @@ title: "Style guide"
     </div>
     <div class="style-guide__container-body">
       <%= partial 'shared/text_tile', locals: {
-        section: OpenStruct.new({
-          title: "Lorem ipsum dolor sit amet",
-          content: [
-            "Consectetur adipisicing elit.",
-            "Consequuntur sed aliquam vero repellendus impedit qui.",
-            "Quia labore, quibusdam soluta, corrupti dolor deleniti voluptatum",
-            "Corporis quidem vero, beatae eius voluptatem quod!"
-          ],
-          image: "https://placehold.it/480x463"
-        })
+        title: "Lorem ipsum dolor sit amet",
+        content: [
+          "Consectetur adipisicing elit.",
+          "Consequuntur sed aliquam vero repellendus impedit qui.",
+          "Quia labore, quibusdam soluta, corrupti dolor deleniti voluptatum",
+          "Corporis quidem vero, beatae eius voluptatem quod!"
+        ],
+        image: "https://placehold.it/480x463"
       } %>
     </div>
   </div>
@@ -60,10 +54,8 @@ title: "Style guide"
     </div>
     <div class="style-guide__container-body">
       <%= partial 'shared/quote', locals: {
-        section: OpenStruct.new({
-          quote: "Consectetur adipisicing elit. Consequuntur sed aliquam vero repellendus impedit qui. Quia labore, quibusdam soluta, corrupti dolor deleniti voluptatum corporis quidem vero, beatae eius voluptatem quod!",
-          source: "Lorem ipsum"
-        })
+        quote: "Consectetur adipisicing elit. Consequuntur sed aliquam vero repellendus impedit qui. Quia labore, quibusdam soluta, corrupti dolor deleniti voluptatum corporis quidem vero, beatae eius voluptatem quod!",
+        source: "Lorem ipsum"
       } %>
     </div>
   </div>
@@ -108,11 +100,9 @@ title: "Style guide"
     </div>
     <div class="style-guide__container-body">
       <%= partial 'shared/quote_caricature', locals: {
-        section: OpenStruct.new({
-          quote: "Consectetur adipisicing elit. Consequuntur sed aliquam vero repellendus impedit qui. Quia labore, quibusdam soluta, corrupti dolor deleniti voluptatum corporis quidem vero, beatae eius voluptatem quod!",
-          source: "Lorem ipsum",
-          image: "https://via.placeholder.com/150x254"
-        })
+        quote: "Consectetur adipisicing elit. Consequuntur sed aliquam vero repellendus impedit qui. Quia labore, quibusdam soluta, corrupti dolor deleniti voluptatum corporis quidem vero, beatae eius voluptatem quod!",
+        source: "Lorem ipsum",
+        image: "https://via.placeholder.com/150x254"
       } %>
     </div>
   </div>


### PR DESCRIPTION
To allow more flexiblity when creating product stories, we have updated
partial locals to fetch data from a `hash[key]` format, rather than
`hash.key`. This allows us to pass a locals variables directly into the
partial rather than relying on a metadata hash.

For example, currently we produce product story components such as:

```erb

introduction:
  title: "Preparation and scaling for unpredictable re-launch traffic of new V&A digital platform"
  content:
    - "Two-week turnaround to live platform re-launch"
    - "Reduced running costs for Ruby on Rails application, hosted on Amazon Web Services"
    - "Infrastructure and support scaled and in place for online visitor growth"
  image: "/product-stories/v-and-a-museum/macbook.jpg"
  image_description: "User on Macbook"

---

<%= partial 'shared/text_tile', locals: { section: current_page.data.introduction } %>
```

However, when the metadata becomes hundreds line long, it becomes much
more difficult to manage each component.

With this change, we can write components in the style above, or by
directly passing in the values to the locals hash:

```erb
<%= partial 'shared/text_tile', locals: {
  title: "Preparation and scaling for unpredictable re-launch traffic of new V&A digital platform",
  content: [
    "Two-week turnaround to live platform re-launch",
    "Reduced running costs for Ruby on Rails application, hosted on Amazon Web Services",
    "Infrastructure and support scaled and in place for online visitor growth",
  ],
  image: "/product-stories/v-and-a-museum/macbook.jpg",
  image_description: "User on Macbook"
 } %>
```