### PR TITLE
Correctly pass data to partial after recent change

### DIFF
--- a/source/jobs.html.erb
+++ b/source/jobs.html.erb
@@ -160,7 +160,7 @@ published: true
     </div>
   </section>
 
-  <%= partial 'shared/quote_caricature', locals: { section: current_page.data.alumni_quote } %>
+  <%= partial 'shared/quote_caricature', locals: current_page.data.alumni_quote %>
 
   <%= partial 'jobs/contact_us', locals: { roles_count: current_page.data.roles.content.length } %>
 


### PR DESCRIPTION
I missed this file when changing how partials can be used [1], resulting
in no data being sent to the partial and rendering as empty quotes.

[1] https://github.com/unboxed/unboxed.co/commit/8a975ded5512ad6887820f6847adb77874767085

---

Currently on https://unboxed.co/jobs/:

<img width="971" alt="screen shot 2018-04-11 at 16 06 41" src="https://user-images.githubusercontent.com/885223/38625435-5c235674-3da2-11e8-9fc6-6c93e554c068.png">

Should be:

<img width="976" alt="screen shot 2018-04-11 at 16 06 30" src="https://user-images.githubusercontent.com/885223/38625444-6480e606-3da2-11e8-99eb-c5a4c2632ec4.png">
