### PR TITLE
Use correct branch for Netlify CMS

### DIFF
--- a/source/admin/config.yml
+++ b/source/admin/config.yml
@@ -1,7 +1,7 @@
 backend:
   name: 'github'
   repo: 'unboxed/unboxed.co'
-  branch: 'netlify-cms'
+  branch: 'production'
 
 media_folder: 'source/assets/images/uploads'
 public_folder: '/assets/images/uploads'


### PR DESCRIPTION
The `netlify-cms` branch no longer exists after being into `production`.