### PR TITLE
Changed title of GOV.UK tile

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -52,7 +52,7 @@ products:
       image: "/assets/images/homepage/logo-gstt.gif"
     - name: "Apps for Good"
       image: "/assets/images/homepage/logo-apps-for-good.gif"
-    - name: "Government UK"
+    - name: "GOV.UK"
       image: "/assets/images/homepage/logo-govuk.jpg"
     - name: "Ministry of Justice"
       image: "/assets/images/homepage/logo-moj.gif"


### PR DESCRIPTION
Changed title from 'Government UK' to 'GOV.UK' on homepage client tile, as a more suitable title
https://github.com/unboxed/unboxed.co/pull/468