### PR TITLE
Fixes spacing for blog titles on mobile

### DIFF
--- a/source/assets/stylesheets/styles/_blog_header.scss
+++ b/source/assets/stylesheets/styles/_blog_header.scss
@@ -1,5 +1,9 @@
 .blog-header {
-  padding: 40px 0 0;
+  padding: 40px 0 40px 0;
+
+  @include breakpoint($tablet-breakpoint) {
+    padding: 40px 0 0;
+  }
 }
 
 .blog-header__container {


### PR DESCRIPTION
## Before

![screen shot 2018-10-26 at 15 07 16](https://user-images.githubusercontent.com/1354439/47571612-e5b06380-d930-11e8-89f1-9bef44b3cb33.png)

## After 

![screen shot 2018-10-26 at 15 07 27](https://user-images.githubusercontent.com/1354439/47571634-f06af880-d930-11e8-987a-b367e7e1f7f0.png)
