### PR TITLE
Remove the developer ad from the website

### DIFF
--- a/source/jobs.html.erb
+++ b/source/jobs.html.erb
@@ -21,11 +21,6 @@ unboxed_meeting_image:
 roles:
   title: Roles we are looking to fill
   content:
-    - name: Developers and Senior Developers
-      text: >-
-        Our developers thrive on collaboration with customers and delivering
-        digital products.
-      link: /jobs/developer_and_senior_developer
     - name: Senior Digital Product Designer
       text: >-
         Our designers are passionate about user experience and user-centred, participatory design.


### PR DESCRIPTION
We're not hiring developers atm, so taken down the ad. Left the actual file in because we'll put it up again soon enough. 